### PR TITLE
Fix query

### DIFF
--- a/samples/AspireEventSample/AspireEventSample.ApiService/Program.cs
+++ b/samples/AspireEventSample/AspireEventSample.ApiService/Program.cs
@@ -93,7 +93,6 @@ app.MapGet("/weatherforecast", () =>
 app.MapGet("/getMultiProjection",async ([FromServices]IClusterClient clusterClient, [FromServices] IMultiProjectorsType multiProjectorsType) =>
 {
     var multiProjectorGrain = clusterClient.GetGrain<IMultiProjectorGrain>(nameof(BranchMultiProjector));
-    await multiProjectorGrain.RebuildStateAsync();
     var state = await multiProjectorGrain.GetStateAsync();
     return multiProjectorsType.ToTypedState(state.ToMultiProjectorState());
 }).WithName("GetMultiProjection")

--- a/samples/AspireEventSample/Sekiban.Pure.OrleansEventSourcing/MultiProjectorGrain.cs
+++ b/samples/AspireEventSample/Sekiban.Pure.OrleansEventSourcing/MultiProjectorGrain.cs
@@ -21,19 +21,7 @@ public class MultiProjectorGrain(IMultiProjectorsType multiProjectorsType, [Pers
     public override async Task OnActivateAsync(CancellationToken cancellationToken)
     {
         await base.OnActivateAsync(cancellationToken);
-        
-        if (safeState.State is null)
-        {
-            var projector = GetProjectorFromGrainName();
-            var newState = new OrleansMultiProjectorState(
-                projector,
-                Guid.Empty,
-                string.Empty,
-                0,
-                0,
-                "default");
-            await safeState.WriteStateAsync();
-        }
+        await safeState.ReadStateAsync();
     }
     
     public override async Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
@@ -107,7 +95,7 @@ public class MultiProjectorGrain(IMultiProjectorsType multiProjectorsType, [Pers
 
     public async Task BuildStateAsync()
     {
-        if (safeState.State is null)
+        if (safeState.RecordExists == false)
         {
             await RebuildStateAsync();
             return;


### PR DESCRIPTION
This pull request includes several changes to the `samples/AspireEventSample` project, focusing on code simplification, optimization, and consistency improvements. The most important changes are grouped by their themes below:

### Code Simplification and Optimization:

* Removed the `RebuildStateAsync` call from the `GetMultiProjection` endpoint in `Program.cs`, which simplifies the endpoint logic.
* Refactored the `CosmosDbEventReader` class by removing the `CreateDefaultOptions` method and inlining its logic directly where needed, reducing complexity and improving readability. [[1]](diffhunk://#diff-ba62eb613193fcb696b364630b7dff626b88ffc1a5e63a577d9a8be3567d69ebL13-L18) [[2]](diffhunk://#diff-ba62eb613193fcb696b364630b7dff626b88ffc1a5e63a577d9a8be3567d69ebL112-R132)
* Simplified the `ProcessEvents` method in `CosmosDbEventReader` by condensing conditional checks and removing unnecessary code.

### Consistency Improvements:

* Standardized the use of `CosmosLinqSerializerOptions` with `CamelCase` property naming policy in `CosmosDbEventReader` to ensure consistent serialization across queries. [[1]](diffhunk://#diff-ba62eb613193fcb696b364630b7dff626b88ffc1a5e63a577d9a8be3567d69ebL29-R29) [[2]](diffhunk://#diff-ba62eb613193fcb696b364630b7dff626b88ffc1a5e63a577d9a8be3567d69ebL63-L76)
* Ensured consistent formatting and spacing in `CosmosDbEventReader` by correcting the placement of braces and aligning the code style.

### Bug Fixes:

* Fixed the initialization logic in `MultiProjectorGrain` by replacing the null check on `safeState.State` with a check on `safeState.RecordExists`, ensuring the state is read correctly on activation. [[1]](diffhunk://#diff-a22d79940d9ceb214688c15fe82e4345b4deab77fbb58e9e9e4ef187a2589931L24-R24) [[2]](diffhunk://#diff-a22d79940d9ceb214688c15fe82e4345b4deab77fbb58e9e9e4ef187a2589931L110-R98)