### PR TITLE
Enhance query handling by updating IMultiProjectorGrain to return Orl…

### DIFF
--- a/samples/AspireEventSample/AspireEventSample.ApiService/Program.cs
+++ b/samples/AspireEventSample/AspireEventSample.ApiService/Program.cs
@@ -172,10 +172,12 @@ apiRoute.MapGet("/branch/{branchId}/reload", async ([FromRoute] Guid branchId,
     .WithOpenApi();
 
 apiRoute.MapGet("/branchExists/{nameContains}",
-        async ([FromRoute] string nameContains, [FromServices] IClusterClient clusterClient) =>
+        async ([FromRoute] string nameContains, [FromServices] IClusterClient clusterClient,
+            [FromServices] IQueryTypes queryTypes) =>
         {
             var multiProjectorGrain = clusterClient.GetGrain<IMultiProjectorGrain>(nameof(BranchMultiProjector));
-            return await multiProjectorGrain.QueryAsync(new BranchExistsQuery(nameContains));
+            var result = await multiProjectorGrain.QueryAsync(new BranchExistsQuery(nameContains));
+            return queryTypes.ToTypedQueryResult(result.ToQueryResultGeneral()).UnwrapBox();
         }).WithName("BranchExists")
     .WithOpenApi();
 

--- a/samples/AspireEventSample/AspireEventSample.ApiService/WeatherForecast.cs
+++ b/samples/AspireEventSample/AspireEventSample.ApiService/WeatherForecast.cs
@@ -24,41 +24,47 @@ internal record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary
 public partial class AspireEventSampleApiServiceEventsJsonContext : JsonSerializerContext
 {
 }
-
+//
 // public class AspireEventSampleApiServiceQueryTypes : IQueryTypes
 // {
-//     public Task<ResultBox<IQueryResult>> ExecuteAsQueryResult<TMultiProjector>(
+//     public Task<ResultBox<IQueryResult>> ExecuteAsQueryResult(
 //         IQueryCommon query,
 //         Func<IMultiProjectionEventSelector, Task<ResultBox<IMultiProjectorStateCommon>>> repositoryLoader)
-//         where TMultiProjector : IMultiProjector<TMultiProjector>
 //     {
 //         return (query, repositoryLoader) switch
 //         {
-//             (BranchExistsQuery q, Func<IMultiProjectionEventSelector, Task<ResultBox<IMultiProjectorStateCommon>>>
-//                 loader) =>
-//                 new QueryExecutor().ExecuteAsQueryResult(q,
-//                     selector => loader(selector)
-//                         .Conveyor(MultiProjectionState<BranchMultiProjector>.FromCommon)),
+//             (BranchExistsQuery q,
+//                 Func<IMultiProjectionEventSelector, Task<ResultBox<IMultiProjectorStateCommon>>> loader) =>
+//                 new QueryExecutor().ExecuteAsQueryResult(q, selector => loader(selector)
+//                     .Conveyor(MultiProjectionState<BranchMultiProjector>
+//                         .FromCommon)),
 //             _ => Task.FromResult(ResultBox<IQueryResult>.FromException(
-//                 new SekibanQueryTypeException(
-//                     $"Unknown query type {query.GetType().Name} with {typeof(TMultiProjector).Name}")))
+//                 new SekibanQueryTypeException($"Unknown query type {query.GetType().Name}")))
 //         };
 //     }
 //
-//     public Task<ResultBox<IListQueryResult>> ExecuteAsQueryResult<TMultiProjector>(
+//     public Task<ResultBox<IListQueryResult>> ExecuteAsQueryResult(
 //         IListQueryCommon query,
 //         Func<IMultiProjectionEventSelector, Task<ResultBox<IMultiProjectorStateCommon>>> repositoryLoader)
-//         where TMultiProjector : IMultiProjector<TMultiProjector>
 //     {
 //         return (query, repositoryLoader) switch
 //         {
-//             (SimpleBranchListQuery q, Func<IMultiProjectionEventSelector, Task<ResultBox<IMultiProjectorStateCommon>>>
-//                 loader) =>
+//             (SimpleBranchListQuery q,
+//                 Func<IMultiProjectionEventSelector, Task<ResultBox<IMultiProjectorStateCommon>>> loader) =>
 //                 new QueryExecutor().ExecuteAsQueryResult(q, selector => loader(selector)
-//                     .Conveyor(MultiProjectionState<BranchMultiProjector>.FromCommon)),
+//                     .Conveyor(MultiProjectionState<BranchMultiProjector>
+//                         .FromCommon)),
 //             _ => Task.FromResult(ResultBox<IListQueryResult>.FromException(
-//                 new SekibanQueryTypeException(
-//                     $"Unknown query type {query.GetType().Name} with {typeof(TMultiProjector).Name}")))
+//                 new SekibanQueryTypeException($"Unknown query type {query.GetType().Name} ")))
+//         };
+//     }
+//
+//     public ResultBox<IQueryResult> ToTypedQueryResult(QueryResultGeneral general)
+//     {
+//         return general.Query switch
+//         {
+//             BranchExistsQuery => new QueryResult<bool>((bool)general.Value),
+//             _ => throw new SekibanQueryTypeException($"Unknown query type {general.Query.GetType().Name}")
 //         };
 //     }
 // }

--- a/samples/AspireEventSample/Sekiban.Pure.OrleansEventSourcing/IMultiProjectorGrain.cs
+++ b/samples/AspireEventSample/Sekiban.Pure.OrleansEventSourcing/IMultiProjectorGrain.cs
@@ -1,4 +1,5 @@
 using Sekiban.Pure.Query;
+
 namespace Sekiban.Pure.OrleansEventSourcing;
 
 public interface IMultiProjectorGrain : IGrainWithStringKey
@@ -6,5 +7,5 @@ public interface IMultiProjectorGrain : IGrainWithStringKey
     Task RebuildStateAsync();
     Task BuildStateAsync();
     Task<OrleansMultiProjectorState> GetStateAsync();
-    Task<IOrleansQueryResult> QueryAsync(IQueryCommon query);
+    Task<OrleansQueryResultGeneral> QueryAsync(IQueryCommon query);
 }

--- a/samples/AspireEventSample/Sekiban.Pure.OrleansEventSourcing/MultiProjectorGrain.cs
+++ b/samples/AspireEventSample/Sekiban.Pure.OrleansEventSourcing/MultiProjectorGrain.cs
@@ -154,7 +154,7 @@ public class MultiProjectorGrain(
         return UnsafeState ?? safeState.State;
     }
 
-    public async Task<IOrleansQueryResult> QueryAsync(IQueryCommon query)
+    public async Task<OrleansQueryResultGeneral> QueryAsync(IQueryCommon query)
     {
         var result = await queryTypes.ExecuteAsQueryResult(query, GetProjectorForQuery) ??
                      throw new ApplicationException("Query not found");

--- a/samples/AspireEventSample/Sekiban.Pure.OrleansEventSourcing/OrleansQueryResult.cs
+++ b/samples/AspireEventSample/Sekiban.Pure.OrleansEventSourcing/OrleansQueryResult.cs
@@ -13,4 +13,9 @@ public record OrleansQueryResultGeneral(
         return new OrleansQueryResultGeneral(queryResultGeneral.Value, queryResultGeneral.ResultType,
             queryResultGeneral.Query);
     }
+
+    public QueryResultGeneral ToQueryResultGeneral()
+    {
+        return new QueryResultGeneral(Value, ResultType, Query);
+    }
 }

--- a/samples/AspireEventSample/Sekiban.Pure.SourceGenerator/QueryExecutionExtensionGenerator.cs
+++ b/samples/AspireEventSample/Sekiban.Pure.SourceGenerator/QueryExecutionExtensionGenerator.cs
@@ -105,6 +105,18 @@ public class QueryExecutionExtensionGenerator : IIncrementalGenerator
             "                new SekibanQueryTypeException($\"Unknown query type {query.GetType().Name} \")))");
         sb.AppendLine("        };");
 
+        // Add ToTypedQueryResult method
+        sb.AppendLine();
+        sb.AppendLine("        public ResultBox<IQueryResult> ToTypedQueryResult(QueryResultGeneral general)");
+        sb.AppendLine("            => general.Query switch");
+        sb.AppendLine("            {");
+        foreach (var type in queryTypes.Where(t => t.InterfaceName == "IMultiProjectionQuery"))
+            sb.AppendLine(
+                $"                {type.RecordName} => new QueryResult<{type.Generic3Name}>(({type.Generic3Name})general.Value),");
+        sb.AppendLine(
+            "                _ => throw new SekibanQueryTypeException($\"Unknown query type {general.Query.GetType().Name}\")");
+        sb.AppendLine("            };");
+
         sb.AppendLine("    }");
         sb.AppendLine("}");
 

--- a/samples/AspireEventSample/Sekiban.Pure/Query/IQueryTypes.cs
+++ b/samples/AspireEventSample/Sekiban.Pure/Query/IQueryTypes.cs
@@ -14,4 +14,6 @@ public interface IQueryTypes
         IListQueryCommon query,
         Func<IMultiProjectionEventSelector,
             Task<ResultBox<IMultiProjectorStateCommon>>> repositoryLoader);
+
+    public ResultBox<IQueryResult> ToTypedQueryResult(QueryResultGeneral general);
 }


### PR DESCRIPTION
This pull request includes several changes to improve query handling and type conversions in the AspireEventSample project. The most important changes include modifications to method signatures, the addition of a type conversion method, and updates to query result handling.

### Query Handling Improvements:
* [`samples/AspireEventSample/AspireEventSample.ApiService/Program.cs`](diffhunk://#diff-cf5d5423f99488fa5b480ed2e7c540ff2b19c0f7cdb4df2c879bb95d1aac1517L175-R180): Updated the `MapGet` method to include a new `IQueryTypes` parameter and modified the query result handling to use `ToTypedQueryResult` and `UnwrapBox` methods.

### Type Conversion Enhancements:
* [`samples/AspireEventSample/Sekiban.Pure.OrleansEventSourcing/OrleansQueryResult.cs`](diffhunk://#diff-3f256f92271f6eeb117a3a3b5418b7f3ddcaa26506958e70e66fb93704772982R16-R20): Added the `ToQueryResultGeneral` method to convert `OrleansQueryResultGeneral` back to `QueryResultGeneral`.
* [`samples/AspireEventSample/Sekiban.Pure.SourceGenerator/QueryExecutionExtensionGenerator.cs`](diffhunk://#diff-a91dcb2af170ab4b1f2810f52a3aea576bea90bf49cb15171bc3aa9537c5ad20R108-R119): Added the `ToTypedQueryResult` method to convert `QueryResultGeneral` to a typed query result based on the query type.

### Method Signature Updates:
* [`samples/AspireEventSample/Sekiban.Pure.OrleansEventSourcing/IMultiProjectorGrain.cs`](diffhunk://#diff-43bbcd02c8cd7533143420f1fdc47357e69afa10a4d7c23e79569b0ee15864f1R2-R10): Changed the return type of the `QueryAsync` method from `IOrleansQueryResult` to `OrleansQueryResultGeneral`.
* [`samples/AspireEventSample/Sekiban.Pure.OrleansEventSourcing/MultiProjectorGrain.cs`](diffhunk://#diff-a22d79940d9ceb214688c15fe82e4345b4deab77fbb58e9e9e4ef187a2589931L157-R157): Updated the `QueryAsync` method to return `OrleansQueryResultGeneral` instead of `IOrleansQueryResult`.

### Interface Updates:
* [`samples/AspireEventSample/Sekiban.Pure/Query/IQueryTypes.cs`](diffhunk://#diff-1dded56b4503c5e9f8b6352106498c44e623d94e82b86b79f39c653fddaf723cR17-R18): Added the `ToTypedQueryResult` method to the `IQueryTypes` interface.…eansQueryResultGeneral, refactor query execution methods, and add ToTypedQueryResult for improved type safety.