### PR TITLE
61 simple orleans executor

### DIFF
--- a/samples/AspireEventSample/AspireEventSample.ApiService/Program.cs
+++ b/samples/AspireEventSample/AspireEventSample.ApiService/Program.cs
@@ -148,13 +148,11 @@ apiRoute
         "/branch/{branchId}",
         (
             [FromRoute] Guid branchId,
-            [FromServices] SekibanOrleansExecutor executor) => Task.FromResult(
-            executor
-                .LoadAggregateAsync<BranchProjector>(
-                    PartitionKeys<BranchProjector>.Existing(branchId))
-                .Conveyor(aggregate => executor.GetDomainTypes().AggregateTypes.ToTypedPayload(aggregate))
-                .UnwrapBox()
-        )
+            [FromServices] SekibanOrleansExecutor executor) => executor
+            .LoadAggregateAsync<BranchProjector>(
+                PartitionKeys<BranchProjector>.Existing(branchId))
+            .Conveyor(aggregate => executor.GetDomainTypes().AggregateTypes.ToTypedPayload(aggregate))
+            .UnwrapBox()
     )
     .WithName("GetBranch")
     .WithOpenApi();

--- a/samples/AspireEventSample/AspireEventSample.ApiService/Program.cs
+++ b/samples/AspireEventSample/AspireEventSample.ApiService/Program.cs
@@ -13,7 +13,6 @@ using Sekiban.Pure.Documents;
 using Sekiban.Pure.OrleansEventSourcing;
 using Sekiban.Pure.Postgres;
 using Sekiban.Pure.Projectors;
-using Sekiban.Pure.Query;
 var builder = WebApplication.CreateBuilder(args);
 
 // Add service defaults & Aspire client integrations.
@@ -181,48 +180,29 @@ apiRoute
 apiRoute
     .MapGet(
         "/branchExists/{nameContains}",
-        async (
-            [FromRoute] string nameContains,
-            [FromServices] IClusterClient clusterClient,
-            [FromServices] IQueryTypes queryTypes) =>
-        {
-            var multiProjectorGrain
-                = clusterClient.GetGrain<IMultiProjectorGrain>(BranchMultiProjector.GetMultiProjectorName());
-            var result = await multiProjectorGrain.QueryAsync(new BranchExistsQuery(nameContains));
-            return queryTypes.ToTypedQueryResult(result.ToQueryResultGeneral()).UnwrapBox();
-        })
+        (
+                [FromRoute] string nameContains,
+                [FromServices] SekibanOrleansExecutor executor) =>
+            executor.ExecuteQueryAsync(new BranchExistsQuery(nameContains)).UnwrapBox())
     .WithName("BranchExists")
     .WithOpenApi();
 
 apiRoute
     .MapGet(
         "/searchBranches",
-        async (
-            [FromQuery] string nameContains,
-            [FromServices] IClusterClient clusterClient,
-            [FromServices] IQueryTypes queryTypes) =>
-        {
-            var multiProjectorGrain
-                = clusterClient.GetGrain<IMultiProjectorGrain>(BranchMultiProjector.GetMultiProjectorName());
-            var result = await multiProjectorGrain.QueryAsync(new SimpleBranchListQuery(nameContains));
-            return queryTypes.ToTypedListQueryResult(result.ToListQueryResultGeneral()).UnwrapBox();
-        })
+        (
+                [FromQuery] string nameContains,
+                [FromServices] SekibanOrleansExecutor executor) =>
+            executor.ExecuteQueryAsync(new SimpleBranchListQuery(nameContains)).UnwrapBox())
     .WithName("SearchBranches")
     .WithOpenApi();
 apiRoute
     .MapGet(
         "/searchBranches2",
-        async (
-            [FromQuery] string nameContains,
-            [FromServices] IClusterClient clusterClient,
-            [FromServices] IQueryTypes queryTypes) =>
-        {
-            var multiProjectorGrain
-                = clusterClient.GetGrain<IMultiProjectorGrain>(
-                    AggregateListProjector<BranchProjector>.GetMultiProjectorName());
-            var result = await multiProjectorGrain.QueryAsync(new BranchQueryFromAggregateList(nameContains));
-            return queryTypes.ToTypedListQueryResult(result.ToListQueryResultGeneral()).UnwrapBox();
-        })
+        (
+                [FromQuery] string nameContains,
+                [FromServices] SekibanOrleansExecutor executor) =>
+            executor.ExecuteQueryAsync(new BranchQueryFromAggregateList(nameContains)).UnwrapBox())
     .WithName("SearchBranches2")
     .WithOpenApi();
 

--- a/samples/AspireEventSample/AspireEventSample.UnitTest/AspireEventSampleUnitTest.cs
+++ b/samples/AspireEventSample/AspireEventSample.UnitTest/AspireEventSampleUnitTest.cs
@@ -10,7 +10,7 @@ namespace AspireEventSample.UnitTest;
 
 public class AspireEventSampleUnitTest
 {
-    private DomainTypes DomainTypes { get; }
+    private SekibanDomainTypes SekibanDomainTypes { get; }
         = AspireEventSampleApiServiceDomainTypes.Generate(AspireEventSampleApiServiceEventsJsonContext.Default.Options);
     private ICommandMetadataProvider CommandMetadataProvider { get; }
         = new FunctionCommandMetadataProvider(() => "test");
@@ -26,7 +26,7 @@ public class AspireEventSampleUnitTest
     [Fact]
     public async Task RegisterBranchTest()
     {
-        var executor = new InMemorySekibanExecutor(DomainTypes, CommandMetadataProvider);
+        var executor = new InMemorySekibanExecutor(SekibanDomainTypes, CommandMetadataProvider);
 
         var result1 = await executor.ExecuteCommandAsync(new RegisterBranch("DDD"));
         Assert.True(result1.IsSuccess);
@@ -40,7 +40,7 @@ public class AspireEventSampleUnitTest
     [Fact]
     public async Task SimpleBranchListQueryTest()
     {
-        var executor = new InMemorySekibanExecutor(DomainTypes, CommandMetadataProvider);
+        var executor = new InMemorySekibanExecutor(SekibanDomainTypes, CommandMetadataProvider);
 
         // Register a branch to generate events
         var commandResult = await executor.ExecuteCommandAsync(new RegisterBranch("TestList"));
@@ -54,7 +54,7 @@ public class AspireEventSampleUnitTest
     [Fact]
     public async Task LoadAggregateTest()
     {
-        var executor = new InMemorySekibanExecutor(DomainTypes, CommandMetadataProvider);
+        var executor = new InMemorySekibanExecutor(SekibanDomainTypes, CommandMetadataProvider);
 
         // Register a branch to generate events
         var commandResult = await executor.ExecuteCommandAsync(new RegisterBranch("TestLoad"));

--- a/samples/AspireEventSample/Sekiban.Pure.CosmosDb/CosmosDbEventReader.cs
+++ b/samples/AspireEventSample/Sekiban.Pure.CosmosDb/CosmosDbEventReader.cs
@@ -6,7 +6,7 @@ using Sekiban.Pure.Events;
 using Sekiban.Pure.OrleansEventSourcing;
 namespace Sekiban.Pure.CosmosDb;
 
-public class CosmosDbEventReader(CosmosDbFactory dbFactory, DomainTypes domainTypes) : IEventReader
+public class CosmosDbEventReader(CosmosDbFactory dbFactory, SekibanDomainTypes sekibanDomainTypes) : IEventReader
 {
     private const int DefaultOptionsMax = -1;
 
@@ -129,7 +129,9 @@ public class CosmosDbEventReader(CosmosDbFactory dbFactory, DomainTypes domainTy
             // pick out one item
             if (string.IsNullOrWhiteSpace(item.PayloadTypeName)) continue;
 
-            var converted = domainTypes.EventTypes.DeserializeToTyped(item, dbFactory.GetJsonSerializerOptions());
+            var converted = sekibanDomainTypes.EventTypes.DeserializeToTyped(
+                item,
+                dbFactory.GetJsonSerializerOptions());
             if (converted.IsSuccess) events.Add(converted.GetValue());
             // var toAdd = (registeredEventTypes
             //                  .RegisteredTypes

--- a/samples/AspireEventSample/Sekiban.Pure.CosmosDb/CosmosDbEventWriter.cs
+++ b/samples/AspireEventSample/Sekiban.Pure.CosmosDb/CosmosDbEventWriter.cs
@@ -5,7 +5,7 @@ using Sekiban.Pure.Events;
 using Sekiban.Pure.OrleansEventSourcing;
 namespace Sekiban.Pure.CosmosDb;
 
-public class CosmosDbEventWriter(CosmosDbFactory dbFactory, DomainTypes domainTypes) : IEventWriter
+public class CosmosDbEventWriter(CosmosDbFactory dbFactory, SekibanDomainTypes sekibanDomainTypes) : IEventWriter
 {
 
     public Task SaveEvents<TEvent>(IEnumerable<TEvent> events) where TEvent : IEvent => dbFactory.CosmosActionAsync(
@@ -14,7 +14,7 @@ public class CosmosDbEventWriter(CosmosDbFactory dbFactory, DomainTypes domainTy
         {
             var taskList = events
                 .ToList()
-                .Select(ev => domainTypes.EventTypes.ConvertToEventDocument(ev))
+                .Select(ev => sekibanDomainTypes.EventTypes.ConvertToEventDocument(ev))
                 .Select(ev => SaveEventFromEventDocument(ev.UnwrapBox(), container))
                 .ToList();
             await Task.WhenAll(taskList);

--- a/samples/AspireEventSample/Sekiban.Pure.CosmosDb/Sekiban.Pure.CosmosDb.csproj
+++ b/samples/AspireEventSample/Sekiban.Pure.CosmosDb/Sekiban.Pure.CosmosDb.csproj
@@ -8,23 +8,23 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\Sekiban.Pure\Sekiban.Pure.csproj" />
+        <ProjectReference Include="..\Sekiban.Pure.AspNetCore\Sekiban.Pure.AspNetCore.csproj"/>
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.46.1" />
-      <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.1" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.1" />
-      <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.46.1"/>
+        <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.1"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.1"/>
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
     </ItemGroup>
 
     <ItemGroup>
-      <Reference Include="Microsoft.Extensions.Caching.Abstractions">
-        <HintPath>..\..\..\..\..\..\..\..\usr\local\share\dotnet\shared\Microsoft.AspNetCore.App\9.0.0\Microsoft.Extensions.Caching.Abstractions.dll</HintPath>
-      </Reference>
-      <Reference Include="Microsoft.Extensions.Configuration.Abstractions">
-        <HintPath>..\..\..\..\..\..\..\..\usr\local\share\dotnet\shared\Microsoft.AspNetCore.App\9.0.0\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
-      </Reference>
+        <Reference Include="Microsoft.Extensions.Caching.Abstractions">
+            <HintPath>..\..\..\..\..\..\..\..\usr\local\share\dotnet\shared\Microsoft.AspNetCore.App\9.0.0\Microsoft.Extensions.Caching.Abstractions.dll</HintPath>
+        </Reference>
+        <Reference Include="Microsoft.Extensions.Configuration.Abstractions">
+            <HintPath>..\..\..\..\..\..\..\..\usr\local\share\dotnet\shared\Microsoft.AspNetCore.App\9.0.0\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
+        </Reference>
     </ItemGroup>
 
 </Project>

--- a/samples/AspireEventSample/Sekiban.Pure.CosmosDb/SekibanCosmosClientOptions.cs
+++ b/samples/AspireEventSample/Sekiban.Pure.CosmosDb/SekibanCosmosClientOptions.cs
@@ -1,5 +1,4 @@
 using Microsoft.Azure.Cosmos;
-using System.Text.Json;
 namespace Sekiban.Pure.CosmosDb;
 
 public record SekibanCosmosClientOptions
@@ -9,18 +8,9 @@ public record SekibanCosmosClientOptions
     /// </summary>
     public CosmosClientOptions ClientOptions { get; init; } = new()
     {
-        Serializer = new SekibanCosmosSerializer(),
         AllowBulkExecution = true,
         MaxRetryAttemptsOnRateLimitedRequests = 200,
         ConnectionMode = ConnectionMode.Gateway,
         GatewayModeMaxConnectionLimit = 200
     };
-    public JsonSerializerOptions JsonSerializerOptions { get; init; } = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        PropertyNameCaseInsensitive = true
-    };
-    public static SekibanCosmosClientOptions WithSerializer(JsonSerializerOptions options)
-        => new()
-            { ClientOptions = new CosmosClientOptions { Serializer = new SekibanCosmosSerializer(options) } };
 }

--- a/samples/AspireEventSample/Sekiban.Pure.CosmosDb/SekibanCosmosExtensions.cs
+++ b/samples/AspireEventSample/Sekiban.Pure.CosmosDb/SekibanCosmosExtensions.cs
@@ -1,0 +1,29 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Sekiban.Pure.OrleansEventSourcing;
+namespace Sekiban.Pure.CosmosDb;
+
+public static class SekibanCosmosExtensions
+{
+    public static IHostApplicationBuilder AddSekibanCosmosDb(
+        this IHostApplicationBuilder builder,
+        Func<SekibanCosmosClientOptions, SekibanCosmosClientOptions>? optionsFunc = null)
+    {
+        builder.Services.AddTransient<IEventWriter, CosmosDbEventWriter>();
+        builder.Services.AddTransient<CosmosDbFactory>();
+        builder.Services.AddTransient<IEventReader, CosmosDbEventReader>();
+        builder.Services.AddTransient<ICosmosMemoryCacheAccessor, CosmosMemoryCacheAccessor>();
+        var dbOption =
+            SekibanAzureCosmosDbOption.FromConfiguration(
+                builder.Configuration.GetSection("Sekiban"),
+                (builder.Configuration as IConfigurationRoot)!);
+        var clientOption = optionsFunc is null
+            ? new SekibanCosmosClientOptions()
+            : optionsFunc(new SekibanCosmosClientOptions());
+        builder.Services.AddSingleton(dbOption);
+        builder.Services.AddMemoryCache();
+        builder.Services.AddSingleton(clientOption);
+        return builder;
+    }
+}

--- a/samples/AspireEventSample/Sekiban.Pure.OrleansEventSourcing/AggregateEventHandlerGrain.cs
+++ b/samples/AspireEventSample/Sekiban.Pure.OrleansEventSourcing/AggregateEventHandlerGrain.cs
@@ -6,7 +6,7 @@ namespace Sekiban.Pure.OrleansEventSourcing;
 public class AggregateEventHandlerGrain(
     [PersistentState("aggregate", "Default")]
     IPersistentState<AggregateEventHandlerGrain.ToPersist> state,
-    DomainTypes domainTypes,
+    SekibanDomainTypes sekibanDomainTypes,
     IEventWriter eventWriter,
     IEventReader eventReader) : Grain, IAggregateEventHandlerGrain
 {
@@ -18,7 +18,7 @@ public class AggregateEventHandlerGrain(
     )
     {
         var streamProvider = this.GetStreamProvider("EventStreamProvider");
-        var toStoreEvents = newEvents.ToList().ToEventsAndReplaceTime(domainTypes.EventTypes);
+        var toStoreEvents = newEvents.ToList().ToEventsAndReplaceTime(sekibanDomainTypes.EventTypes);
         if (string.IsNullOrWhiteSpace(expectedLastSortableUniqueId) &&
             _events.Count > 0 &&
             _events.Last().SortableUniqueId != expectedLastSortableUniqueId)

--- a/samples/AspireEventSample/Sekiban.Pure.OrleansEventSourcing/CommandResponseExtensions.cs
+++ b/samples/AspireEventSample/Sekiban.Pure.OrleansEventSourcing/CommandResponseExtensions.cs
@@ -1,9 +1,22 @@
 using Sekiban.Pure.Command.Executor;
-
+using Sekiban.Pure.Events;
 namespace Sekiban.Pure.OrleansEventSourcing;
 
 public static class CommandResponseExtensions
 {
     public static OrleansCommandResponse ToOrleansCommandResponse(this CommandResponse response) =>
-        new(response.PartitionKeys.ToOrleansPartitionKeys(), response.Events.Select(e => e.ToString() ?? String.Empty).ToList(), response.Version);
+        new(
+            response.PartitionKeys.ToOrleansPartitionKeys(),
+            response.Events.Select(OrleansEvent.FromEvent).ToList(),
+            response.Version);
+    public static CommandResponse ToCommandResponse(this OrleansCommandResponse response, IEventTypes eventTypes) =>
+        new(
+            response.PartitionKeys.ToPartitionKeys(),
+            response
+                .Events
+                .Select(e => e.ToEvent(eventTypes))
+                .Where(r => r.IsSuccess)
+                .Select(r => r.GetValue())
+                .ToList(),
+            response.Version);
 }

--- a/samples/AspireEventSample/Sekiban.Pure.OrleansEventSourcing/OrleansCommandResponse.cs
+++ b/samples/AspireEventSample/Sekiban.Pure.OrleansEventSourcing/OrleansCommandResponse.cs
@@ -1,6 +1,9 @@
 namespace Sekiban.Pure.OrleansEventSourcing;
 
 [GenerateSerializer]
-public record OrleansCommandResponse([property:Id(0)]OrleansPartitionKeys PartitionKeys, [property:Id(1)]List<string> Events, [property:Id(2)]int Version)
+public record OrleansCommandResponse(
+    [property: Id(0)] OrleansPartitionKeys PartitionKeys,
+    [property: Id(1)] List<OrleansEvent> Events,
+    [property: Id(2)] int Version)
 {
 }

--- a/samples/AspireEventSample/Sekiban.Pure.OrleansEventSourcing/PartitionKeysExtensions.cs
+++ b/samples/AspireEventSample/Sekiban.Pure.OrleansEventSourcing/PartitionKeysExtensions.cs
@@ -1,5 +1,4 @@
 using Sekiban.Pure.Documents;
-
 namespace Sekiban.Pure.OrleansEventSourcing;
 
 public static class PartitionKeysExtensions

--- a/samples/AspireEventSample/Sekiban.Pure.OrleansEventSourcing/SekibanOrleansExecutor.cs
+++ b/samples/AspireEventSample/Sekiban.Pure.OrleansEventSourcing/SekibanOrleansExecutor.cs
@@ -1,0 +1,64 @@
+using ResultBoxes;
+using Sekiban.Pure.Aggregates;
+using Sekiban.Pure.Command.Executor;
+using Sekiban.Pure.Command.Handlers;
+using Sekiban.Pure.Documents;
+using Sekiban.Pure.Events;
+using Sekiban.Pure.Executors;
+using Sekiban.Pure.Projectors;
+using Sekiban.Pure.Query;
+namespace Sekiban.Pure.OrleansEventSourcing;
+
+public class SekibanOrleansExecutor(
+    IClusterClient clusterClient,
+    SekibanDomainTypes sekibanDomainTypes,
+    ICommandMetadataProvider metadataProvider) : ISekibanExecutor
+{
+
+    public SekibanDomainTypes GetDomainTypes() => sekibanDomainTypes;
+    public async Task<ResultBox<CommandResponse>> ExecuteCommandAsync(
+        ICommandWithHandlerSerializable command,
+        IEvent? relatedEvent = null)
+    {
+        var partitionKeySpecifier = command.GetPartitionKeysSpecifier();
+        var partitionKeys = partitionKeySpecifier.DynamicInvoke(command) as PartitionKeys;
+        if (partitionKeys is null)
+            return ResultBox<CommandResponse>.Error(new ApplicationException("Partition keys can not be found"));
+        var projector = command.GetProjector();
+        var partitionKeyAndProjector = new PartitionKeysAndProjector(partitionKeys, projector);
+        var aggregateProjectorGrain =
+            clusterClient.GetGrain<IAggregateProjectorGrain>(partitionKeyAndProjector.ToProjectorGrainKey());
+        var toReturn = await aggregateProjectorGrain.ExecuteCommandAsync(
+            command,
+            OrleansCommandMetadata.FromCommandMetadata(metadataProvider.GetMetadata()));
+        return toReturn.ToCommandResponse(sekibanDomainTypes.EventTypes);
+    }
+    public Task<ResultBox<TResult>> ExecuteQueryAsync<TResult>(IQueryCommon<TResult> queryCommon)
+        where TResult : notnull
+    {
+        var projectorResult = sekibanDomainTypes.QueryTypes.GetMultiProjector(queryCommon);
+        if (!projectorResult.IsSuccess)
+            return Task.FromResult(ResultBox<TResult>.Error(new ApplicationException("Projector not found")));
+        var nameResult
+            = sekibanDomainTypes.MultiProjectorsType
+                .GetMultiProjectorNameFromMultiProjector(projectorResult.GetValue());
+
+        var multiProjectorGrain
+            = clusterClient.GetGrain<IMultiProjectorGrain>(projectorResult.GetValue());
+        var result = await multiProjectorGrain.QueryAsync(new BranchExistsQuery(nameContains));
+        return queryTypes.ToTypedQueryResult(result.ToQueryResultGeneral()).;
+
+    }
+    public Task<ResultBox<ListQueryResult<TResult>>> ExecuteQueryAsync<TResult>(IListQueryCommon<TResult> queryCommon)
+        where TResult : notnull => throw new NotImplementedException();
+    public async Task<ResultBox<Aggregate>> LoadAggregateAsync<TAggregateProjector>(PartitionKeys partitionKeys)
+        where TAggregateProjector : IAggregateProjector, new()
+    {
+        var partitionKeyAndProjector = new PartitionKeysAndProjector(partitionKeys, new TAggregateProjector());
+
+        var aggregateProjectorGrain =
+            clusterClient.GetGrain<IAggregateProjectorGrain>(partitionKeyAndProjector.ToProjectorGrainKey());
+        var state = await aggregateProjectorGrain.GetStateAsync();
+        return state.ToAggregate();
+    }
+}

--- a/samples/AspireEventSample/Sekiban.Pure.OrleansEventSourcing/SekibanOrleansExecutor.cs
+++ b/samples/AspireEventSample/Sekiban.Pure.OrleansEventSourcing/SekibanOrleansExecutor.cs
@@ -50,7 +50,7 @@ public class SekibanOrleansExecutor(
         return sekibanDomainTypes
             .QueryTypes
             .ToTypedQueryResult(result.ToQueryResultGeneral())
-            .Remap(r => (TResult)r);
+            .Remap(r => (TResult)r.GetValue());
     }
     public async Task<ResultBox<ListQueryResult<TResult>>> ExecuteQueryAsync<TResult>(
         IListQueryCommon<TResult> queryCommon)

--- a/samples/AspireEventSample/Sekiban.Pure.Postgres/PostgresDbEventReader.cs
+++ b/samples/AspireEventSample/Sekiban.Pure.Postgres/PostgresDbEventReader.cs
@@ -13,11 +13,11 @@ public class PostgresDbEventReader : IEventReader
     private readonly IEventTypes _eventTypes;
     private readonly ISekibanSerializer _serializer;
 
-    public PostgresDbEventReader(PostgresDbFactory dbFactory, DomainTypes domainTypes)
+    public PostgresDbEventReader(PostgresDbFactory dbFactory, SekibanDomainTypes sekibanDomainTypes)
     {
         _dbFactory = dbFactory;
-        _eventTypes = domainTypes.EventTypes;
-        _serializer = domainTypes.Serializer;
+        _eventTypes = sekibanDomainTypes.EventTypes;
+        _serializer = sekibanDomainTypes.Serializer;
     }
 
     public async Task<ResultBox<IReadOnlyList<IEvent>>> GetEvents(EventRetrievalInfo eventRetrievalInfo)

--- a/samples/AspireEventSample/Sekiban.Pure.Postgres/PostgresDbEventWriter.cs
+++ b/samples/AspireEventSample/Sekiban.Pure.Postgres/PostgresDbEventWriter.cs
@@ -9,11 +9,11 @@ public class PostgresDbEventWriter : IEventWriter
     private readonly IEventTypes _eventTypes;
     private readonly ISekibanSerializer _serializer;
 
-    public PostgresDbEventWriter(PostgresDbFactory dbFactory, DomainTypes domainTypes)
+    public PostgresDbEventWriter(PostgresDbFactory dbFactory, SekibanDomainTypes sekibanDomainTypes)
     {
         _dbFactory = dbFactory;
-        _eventTypes = domainTypes.EventTypes;
-        _serializer = domainTypes.Serializer;
+        _eventTypes = sekibanDomainTypes.EventTypes;
+        _serializer = sekibanDomainTypes.Serializer;
     }
 
     public async Task SaveEvents<TEvent>(IEnumerable<TEvent> events) where TEvent : IEvent

--- a/samples/AspireEventSample/Sekiban.Pure.Postgres/Sekiban.Pure.Postgres.csproj
+++ b/samples/AspireEventSample/Sekiban.Pure.Postgres/Sekiban.Pure.Postgres.csproj
@@ -17,7 +17,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Sekiban.Pure\Sekiban.Pure.csproj"/>
+        <ProjectReference Include="..\Sekiban.Pure.AspNetCore\Sekiban.Pure.AspNetCore.csproj"/>
     </ItemGroup>
 
 </Project>

--- a/samples/AspireEventSample/Sekiban.Pure.Postgres/SekibanPostgresExtensions.cs
+++ b/samples/AspireEventSample/Sekiban.Pure.Postgres/SekibanPostgresExtensions.cs
@@ -1,0 +1,24 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Sekiban.Pure.OrleansEventSourcing;
+namespace Sekiban.Pure.Postgres;
+
+public static class SekibanPostgresExtensions
+{
+    public static IHostApplicationBuilder AddSekibanPostgresDb(
+        this IHostApplicationBuilder builder)
+    {
+        builder.Services.AddTransient<IEventWriter, PostgresDbEventWriter>();
+        builder.Services.AddTransient<PostgresDbFactory>();
+        builder.Services.AddTransient<IPostgresMemoryCacheAccessor, PostgresMemoryCacheAccessor>();
+        builder.Services.AddTransient<IEventReader, PostgresDbEventReader>();
+        var dbOption =
+            SekibanPostgresDbOption.FromConfiguration(
+                builder.Configuration.GetSection("Sekiban"),
+                (builder.Configuration as IConfigurationRoot)!);
+        builder.Services.AddSingleton(dbOption);
+        builder.Services.AddMemoryCache();
+        return builder;
+    }
+}

--- a/samples/AspireEventSample/Sekiban.Pure.SourceGenerator/DomainTypesGenerator.cs
+++ b/samples/AspireEventSample/Sekiban.Pure.SourceGenerator/DomainTypesGenerator.cs
@@ -55,7 +55,8 @@ public class DomainTypesGenerator : IIncrementalGenerator
         sb.AppendLine("{");
         sb.AppendLine($"    public static class {baseName}DomainTypes");
         sb.AppendLine("    {");
-        sb.AppendLine("        public static DomainTypes Generate(JsonSerializerOptions jsonSerializerOptions = null)");
+        sb.AppendLine(
+            "        public static SekibanDomainTypes Generate(JsonSerializerOptions jsonSerializerOptions = null)");
         sb.AppendLine(
             $"            => new(new {baseName}EventTypes(), new {baseName}AggregateTypes(), new {baseName}AggregateProjectorSpecifier(), new {baseName}QueryTypes(), new {baseName}MultiProjectorTypes(), jsonSerializerOptions);");
         sb.AppendLine("    };");

--- a/samples/AspireEventSample/Sekiban.Pure.SourceGenerator/MultiProjectorTypesGenerator.cs
+++ b/samples/AspireEventSample/Sekiban.Pure.SourceGenerator/MultiProjectorTypesGenerator.cs
@@ -193,6 +193,20 @@ public class MultiProjectorTypesGenerator : IIncrementalGenerator
         sb.AppendLine(
             "                _ => throw new ArgumentException($\"No projector found for grain name: {grainName}\")");
         sb.AppendLine("            };");
+        sb.AppendLine("        public ResultBox<string> GetMultiProjectorNameFromMultiProjector(IMultiProjectorCommon multiProjector)");
+        sb.AppendLine("            => multiProjector switch");
+        sb.AppendLine("            {");
+        foreach (var type in multiProjectorTypes)
+        {
+            var className = type.TypeName.Split('.').Last();
+            sb.AppendLine($"                {type.TypeName} projector => ResultBox.FromValue({type.TypeName}.GetMultiProjectorName()),");
+        }
+        foreach (var type in aggregateProjectorTypes)
+        {
+            sb.AppendLine($"                AggregateListProjector<{type.RecordName}> aggregator => ResultBox.FromValue(AggregateListProjector<{type.RecordName}>.GetMultiProjectorName()),");
+        }
+        sb.AppendLine("                _ => ResultBox<string>.Error(new ApplicationException(multiProjector.GetType().Name))");
+        sb.AppendLine("            };");
         sb.AppendLine("    }");
         sb.AppendLine("}");
 

--- a/samples/AspireEventSample/Sekiban.Pure/Executors/ISekibanExecutor.cs
+++ b/samples/AspireEventSample/Sekiban.Pure/Executors/ISekibanExecutor.cs
@@ -10,6 +10,7 @@ namespace Sekiban.Pure.Executors;
 
 public interface ISekibanExecutor
 {
+    public SekibanDomainTypes GetDomainTypes();
     public Task<ResultBox<CommandResponse>> ExecuteCommandAsync(
         ICommandWithHandlerSerializable command,
         IEvent? relatedEvent = null);

--- a/samples/AspireEventSample/Sekiban.Pure/Executors/InMemorySekibanExecutor.cs
+++ b/samples/AspireEventSample/Sekiban.Pure/Executors/InMemorySekibanExecutor.cs
@@ -10,12 +10,13 @@ using Sekiban.Pure.Repositories;
 namespace Sekiban.Pure.Executors;
 
 public class InMemorySekibanExecutor(
-    DomainTypes domainTypes,
+    SekibanDomainTypes sekibanDomainTypes,
     ICommandMetadataProvider metadataProvider) : ISekibanExecutor
 {
     private readonly CommandExecutor _commandExecutor = new()
-        { EventTypes = domainTypes.EventTypes };
+        { EventTypes = sekibanDomainTypes.EventTypes };
 
+    public SekibanDomainTypes GetDomainTypes() => sekibanDomainTypes;
     public async Task<ResultBox<CommandResponse>> ExecuteCommandAsync(
         ICommandWithHandlerSerializable command,
         IEvent? relatedEvent = null)
@@ -35,14 +36,14 @@ public class InMemorySekibanExecutor(
     public async Task<ResultBox<TResult>> ExecuteQueryAsync<TResult>(IQueryCommon<TResult> queryCommon)
         where TResult : notnull
     {
-        var projectorResult = domainTypes.QueryTypes.GetMultiProjector(queryCommon);
+        var projectorResult = sekibanDomainTypes.QueryTypes.GetMultiProjector(queryCommon);
         if (projectorResult.IsSuccess)
         {
             var projector = projectorResult.GetValue();
             var events = Repository.Events;
             var projectionResult = events
                 .ToResultBox()
-                .ReduceEach(projector, (ev, proj) => domainTypes.MultiProjectorsType.Project(proj, ev));
+                .ReduceEach(projector, (ev, proj) => sekibanDomainTypes.MultiProjectorsType.Project(proj, ev));
             if (projectionResult.IsSuccess)
             {
                 var projection = projectionResult.GetValue();
@@ -54,9 +55,10 @@ public class InMemorySekibanExecutor(
                     events.Count,
                     0,
                     lastEvent?.PartitionKeys.RootPartitionKey ?? "default");
-                var typedMultiProjectionState = domainTypes.MultiProjectorsType.ToTypedState(multiProjectionState);
+                var typedMultiProjectionState
+                    = sekibanDomainTypes.MultiProjectorsType.ToTypedState(multiProjectionState);
                 var queryExecutor = new QueryExecutor();
-                var queryResult = await domainTypes.QueryTypes.ExecuteAsQueryResult(
+                var queryResult = await sekibanDomainTypes.QueryTypes.ExecuteAsQueryResult(
                     queryCommon,
                     selector => typedMultiProjectionState
                         .ToResultBox()
@@ -72,14 +74,14 @@ public class InMemorySekibanExecutor(
         IListQueryCommon<TResult> queryCommon)
         where TResult : notnull
     {
-        var projectorResult = domainTypes.QueryTypes.GetMultiProjector(queryCommon);
+        var projectorResult = sekibanDomainTypes.QueryTypes.GetMultiProjector(queryCommon);
         if (projectorResult.IsSuccess)
         {
             var projector = projectorResult.GetValue();
             var events = Repository.Events;
             var projectionResult = events
                 .ToResultBox()
-                .ReduceEach(projector, (ev, proj) => domainTypes.MultiProjectorsType.Project(proj, ev));
+                .ReduceEach(projector, (ev, proj) => sekibanDomainTypes.MultiProjectorsType.Project(proj, ev));
             if (projectionResult.IsSuccess)
             {
                 var projection = projectionResult.GetValue();
@@ -91,9 +93,10 @@ public class InMemorySekibanExecutor(
                     events.Count,
                     0,
                     lastEvent?.PartitionKeys.RootPartitionKey ?? "default");
-                var typedMultiProjectionState = domainTypes.MultiProjectorsType.ToTypedState(multiProjectionState);
+                var typedMultiProjectionState
+                    = sekibanDomainTypes.MultiProjectorsType.ToTypedState(multiProjectionState);
                 var queryExecutor = new QueryExecutor();
-                var queryResult = await domainTypes.QueryTypes.ExecuteAsQueryResult(
+                var queryResult = await sekibanDomainTypes.QueryTypes.ExecuteAsQueryResult(
                     queryCommon,
                     selector => typedMultiProjectionState
                         .ToResultBox()

--- a/samples/AspireEventSample/Sekiban.Pure/Projectors/IMultiProjectorsType.cs
+++ b/samples/AspireEventSample/Sekiban.Pure/Projectors/IMultiProjectorsType.cs
@@ -14,5 +14,6 @@ public interface IMultiProjectorTypes
     }
 
     IMultiProjectorCommon GetProjectorFromMultiProjectorName(string grainName);
+    ResultBox<string> GetMultiProjectorNameFromMultiProjector(IMultiProjectorCommon multiProjector);
     IMultiProjectorStateCommon ToTypedState(MultiProjectionState state);
 }

--- a/samples/AspireEventSample/Sekiban.Pure/Query/IQueryCommon.cs
+++ b/samples/AspireEventSample/Sekiban.Pure/Query/IQueryCommon.cs
@@ -1,6 +1,6 @@
 namespace Sekiban.Pure.Query;
 
 public interface IQueryCommon<TOutput> : IQueryCommon where TOutput : notnull;
-public interface IQueryCommon<TQuery, TOutput> : IQueryCommon where TOutput : notnull
+public interface IQueryCommon<TQuery, TOutput> : IQueryCommon<TOutput> where TOutput : notnull
     where TQuery : IQueryCommon<TQuery, TOutput>, IEquatable<TQuery>;
 public interface IQueryCommon;

--- a/samples/AspireEventSample/Sekiban.Pure/SekibanDomainTypes.cs
+++ b/samples/AspireEventSample/Sekiban.Pure/SekibanDomainTypes.cs
@@ -6,9 +6,9 @@ using Sekiban.Pure.Serialize;
 using System.Text.Json;
 namespace Sekiban.Pure;
 
-public record DomainTypes
+public record SekibanDomainTypes
 {
-    public DomainTypes(
+    public SekibanDomainTypes(
         IEventTypes eventTypes,
         IAggregateTypes aggregateTypes,
         IAggregateProjectorSpecifier aggregateProjectorSpecifier,


### PR DESCRIPTION
This pull request includes significant changes to the `AspireEventSample` project, focusing on dependency updates, code simplification, and refactoring for better maintainability. The most important changes include adding new service registrations, replacing domain type references with `SekibanDomainTypes`, and simplifying the database configuration.

### Dependency Updates:
* Added `Sekiban.Pure.AspNetCore` to the list of using directives in `Program.cs`.

### Service Registrations:
* Added singleton and transient service registrations for `AspireEventSampleApiServiceDomainTypes`, `CommandMetadataProvider`, `HttpExecutingUserProvider`, and `SekibanOrleansExecutor` in `Program.cs`.

### Code Simplification:
* Replaced manual service registrations for CosmosDB and Postgres with `builder.AddSekibanCosmosDb()` and `builder.AddSekibanPostgresDb()`, respectively, in `Program.cs`.

### Refactoring:
* Updated references from `DomainTypes` to `SekibanDomainTypes` across multiple files, including `Program.cs`, `CosmosDbEventReader.cs`, `CosmosDbEventWriter.cs`, and `CosmosDbFactory.cs`. [[1]](diffhunk://#diff-cf5d5423f99488fa5b480ed2e7c540ff2b19c0f7cdb4df2c879bb95d1aac1517L112-R119) [[2]](diffhunk://#diff-ba62eb613193fcb696b364630b7dff626b88ffc1a5e63a577d9a8be3567d69ebL9-R9) [[3]](diffhunk://#diff-8dc52fb7a241b0225998c84d298d3e5f09ee6acdfa8cb2239d22109c3818e0feL8-R8) [[4]](diffhunk://#diff-ed56519916d9f841eca63e469090b14c1aa12bba81f0f8a9fd84036c78ee6432L1-R32)
* Simplified method implementations in `CosmosDbFactory.cs` by using expression-bodied members and removing redundant code. [[1]](diffhunk://#diff-ed56519916d9f841eca63e469090b14c1aa12bba81f0f8a9fd84036c78ee6432L75-R89) [[2]](diffhunk://#diff-ed56519916d9f841eca63e469090b14c1aa12bba81f0f8a9fd84036c78ee6432L111-R98)

### Unit Tests:
* Updated unit tests to use `SekibanDomainTypes` instead of `DomainTypes` in `AspireEventSampleUnitTest.cs`. [[1]](diffhunk://#diff-28577f3bf9cbf115c36fb2b0d22bb69d767eabaa25c5a14b3b3d49f894565fcbL13-R13) [[2]](diffhunk://#diff-28577f3bf9cbf115c36fb2b0d22bb69d767eabaa25c5a14b3b3d49f894565fcbL29-R29) [[3]](diffhunk://#diff-28577f3bf9cbf115c36fb2b0d22bb69d767eabaa25c5a14b3b3d49f894565fcbL43-R43) [[4]](diffhunk://#diff-28577f3bf9cbf115c36fb2b0d22bb69d767eabaa25c5a14b3b3d49f894565fcbL57-R57)