### PR TITLE
66 query and command can use di

### DIFF
--- a/samples/AspireEventSample/AspireEventSample.UnitTest/AspireEventSampleUnitTest.cs
+++ b/samples/AspireEventSample/AspireEventSample.UnitTest/AspireEventSampleUnitTest.cs
@@ -1,6 +1,7 @@
 ﻿using AspireEventSample.ApiService.Aggregates.Branches;
 using AspireEventSample.ApiService.Generated;
 using AspireEventSample.ApiService.Projections;
+using Microsoft.Extensions.DependencyInjection;
 using Sekiban.Pure;
 using Sekiban.Pure.Command.Handlers;
 using Sekiban.Pure.Documents;
@@ -27,7 +28,7 @@ public class AspireEventSampleUnitTest
     [Fact]
     public async Task RegisterBranchTest()
     {
-        var executor = new InMemorySekibanExecutor(SekibanDomainTypes, CommandMetadataProvider, new Repository());
+        var executor = new InMemorySekibanExecutor(SekibanDomainTypes, CommandMetadataProvider, new Repository(), new ServiceCollection().BuildServiceProvider());
 
         var result1 = await executor.ExecuteCommandAsync(new RegisterBranch("DDD"));
         Assert.True(result1.IsSuccess);
@@ -41,7 +42,7 @@ public class AspireEventSampleUnitTest
     [Fact]
     public async Task SimpleBranchListQueryTest()
     {
-        var executor = new InMemorySekibanExecutor(SekibanDomainTypes, CommandMetadataProvider, new Repository());
+        var executor = new InMemorySekibanExecutor(SekibanDomainTypes, CommandMetadataProvider, new Repository(), new ServiceCollection().BuildServiceProvider());
 
         // Register a branch to generate events
         var commandResult = await executor.ExecuteCommandAsync(new RegisterBranch("TestList"));
@@ -55,7 +56,7 @@ public class AspireEventSampleUnitTest
     [Fact]
     public async Task LoadAggregateTest()
     {
-        var executor = new InMemorySekibanExecutor(SekibanDomainTypes, CommandMetadataProvider, new Repository());
+        var executor = new InMemorySekibanExecutor(SekibanDomainTypes, CommandMetadataProvider, new Repository(), new ServiceCollection().BuildServiceProvider());
 
         // Register a branch to generate events
         var commandResult = await executor.ExecuteCommandAsync(new RegisterBranch("TestLoad"));

--- a/samples/AspireEventSample/Sekiban.Pure.OrleansEventSourcing/AggregateProjectorGrain.cs
+++ b/samples/AspireEventSample/Sekiban.Pure.OrleansEventSourcing/AggregateProjectorGrain.cs
@@ -7,7 +7,7 @@ namespace Sekiban.Pure.OrleansEventSourcing;
 public class AggregateProjectorGrain(
     [PersistentState("aggregate", "Default")]
     IPersistentState<Aggregate> state,
-    SekibanDomainTypes sekibanDomainTypes) : Grain, IAggregateProjectorGrain
+    SekibanDomainTypes sekibanDomainTypes, IServiceProvider serviceProvider) : Grain, IAggregateProjectorGrain
 {
     private OptionalValue<PartitionKeysAndProjector> _partitionKeysAndProjector
         = OptionalValue<PartitionKeysAndProjector>.Empty;
@@ -102,7 +102,7 @@ public class AggregateProjectorGrain(
             GetPartitionKeysAndProjector().Projector,
             sekibanDomainTypes.EventTypes,
             await GetStateInternalAsync(eventGrain));
-        var commandExecutor = new CommandExecutor { EventTypes = sekibanDomainTypes.EventTypes };
+        var commandExecutor = new CommandExecutor(serviceProvider) { EventTypes = sekibanDomainTypes.EventTypes };
         var result = await sekibanDomainTypes
             .CommandTypes
             .ExecuteGeneral(

--- a/samples/AspireEventSample/Sekiban.Pure.OrleansEventSourcing/MultiProjectorGrain.cs
+++ b/samples/AspireEventSample/Sekiban.Pure.OrleansEventSourcing/MultiProjectorGrain.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.DependencyInjection;
 using ResultBoxes;
 using Sekiban.Pure.Documents;
 using Sekiban.Pure.Projectors;
@@ -164,7 +165,10 @@ public class MultiProjectorGrain(
 
     public async Task<OrleansQueryResultGeneral> QueryAsync(IQueryCommon query)
     {
-        var result = await sekibanDomainTypes.QueryTypes.ExecuteAsQueryResult(query, GetProjectorForQuery) ??
+        var result = await sekibanDomainTypes.QueryTypes.ExecuteAsQueryResult(
+                query,
+                GetProjectorForQuery,
+                new ServiceCollection().BuildServiceProvider()) ??
             throw new ApplicationException("Query not found");
         return result
             .Remap(value => value.ToGeneral(query))
@@ -174,7 +178,8 @@ public class MultiProjectorGrain(
 
     public async Task<OrleansListQueryResultGeneral> QueryAsync(IListQueryCommon query)
     {
-        var result = await sekibanDomainTypes.QueryTypes.ExecuteAsQueryResult(query, GetProjectorForQuery) ??
+        var result = await sekibanDomainTypes.QueryTypes.ExecuteAsQueryResult(query, GetProjectorForQuery,
+                new ServiceCollection().BuildServiceProvider()) ??
             throw new ApplicationException("Query not found");
         return result
             .Remap(value => value.ToGeneral(query))

--- a/samples/AspireEventSample/Sekiban.Pure.SourceGenerator/QueryExecutionExtensionGenerator.cs
+++ b/samples/AspireEventSample/Sekiban.Pure.SourceGenerator/QueryExecutionExtensionGenerator.cs
@@ -65,7 +65,7 @@ public class QueryExecutionExtensionGenerator : IIncrementalGenerator
         sb.AppendLine("        public Task<ResultBox<IQueryResult>> ExecuteAsQueryResult(");
         sb.AppendLine("            IQueryCommon query,");
         sb.AppendLine(
-            "            Func<IMultiProjectionEventSelector, Task<ResultBox<IMultiProjectorStateCommon>>> repositoryLoader)");
+            "            Func<IMultiProjectionEventSelector, Task<ResultBox<IMultiProjectorStateCommon>>> repositoryLoader, IServiceProvider serviceProvider)");
         sb.AppendLine("        => (query, repositoryLoader) switch");
         sb.AppendLine("        {");
 
@@ -73,7 +73,8 @@ public class QueryExecutionExtensionGenerator : IIncrementalGenerator
         {
             sb.AppendLine(
                 $"            ({type.RecordName} q, Func<IMultiProjectionEventSelector, Task<ResultBox<IMultiProjectorStateCommon>>> loader) =>");
-            sb.AppendLine("                new QueryExecutor().ExecuteAsQueryResult(q, selector => loader(selector)");
+            sb.AppendLine(
+                "                new QueryExecutor(serviceProvider).ExecuteAsQueryResult(q, selector => loader(selector)");
             sb.AppendLine($"                        .Conveyor(MultiProjectionState<{type.Generic1Name}>.FromCommon)),");
         }
 
@@ -88,7 +89,7 @@ public class QueryExecutionExtensionGenerator : IIncrementalGenerator
         sb.AppendLine("        public Task<ResultBox<IListQueryResult>> ExecuteAsQueryResult(");
         sb.AppendLine("            IListQueryCommon query,");
         sb.AppendLine(
-            "            Func<IMultiProjectionEventSelector, Task<ResultBox<IMultiProjectorStateCommon>>> repositoryLoader)");
+            "            Func<IMultiProjectionEventSelector, Task<ResultBox<IMultiProjectorStateCommon>>> repositoryLoader, IServiceProvider serviceProvider)");
         sb.AppendLine("        => (query, repositoryLoader) switch");
         sb.AppendLine("        {");
 
@@ -96,7 +97,8 @@ public class QueryExecutionExtensionGenerator : IIncrementalGenerator
         {
             sb.AppendLine(
                 $"            ({type.RecordName} q, Func<IMultiProjectionEventSelector, Task<ResultBox<IMultiProjectorStateCommon>>> loader) =>");
-            sb.AppendLine("                new QueryExecutor().ExecuteAsQueryResult(q, selector => loader(selector)");
+            sb.AppendLine(
+                "                new QueryExecutor(serviceProvider).ExecuteAsQueryResult(q, selector => loader(selector)");
             sb.AppendLine($"                        .Conveyor(MultiProjectionState<{type.Generic1Name}>.FromCommon)),");
         }
 

--- a/samples/AspireEventSample/Sekiban.Pure/Command/Handlers/ICommandContextWithoutState.cs
+++ b/samples/AspireEventSample/Sekiban.Pure/Command/Handlers/ICommandContextWithoutState.cs
@@ -15,4 +15,5 @@ public interface ICommandContextWithoutState
     public ResultBox<EventOrNone> AppendEvent(IEventPayload eventPayload);
     public EventMetadata EventMetadata { get; }
     public CommandMetadata CommandMetadata { get; }
+    public ResultBox<T> GetService<T>() where T : notnull;
 }

--- a/samples/AspireEventSample/Sekiban.Pure/Executors/InMemorySekibanExecutor.cs
+++ b/samples/AspireEventSample/Sekiban.Pure/Executors/InMemorySekibanExecutor.cs
@@ -12,10 +12,12 @@ namespace Sekiban.Pure.Executors;
 public class InMemorySekibanExecutor(
     SekibanDomainTypes sekibanDomainTypes,
     ICommandMetadataProvider metadataProvider,
-    Repository repository, IServiceProvider serviceProvider) : ISekibanExecutor
+    Repository repository,
+    IServiceProvider serviceProvider) : ISekibanExecutor
 {
     public Repository Repository { get; set; } = repository;
-    private readonly CommandExecutor _commandExecutor = new(serviceProvider) { EventTypes = sekibanDomainTypes.EventTypes };
+    private readonly CommandExecutor _commandExecutor = new(serviceProvider)
+        { EventTypes = sekibanDomainTypes.EventTypes };
 
     public SekibanDomainTypes GetDomainTypes() => sekibanDomainTypes;
     public async Task<ResultBox<CommandResponse>> ExecuteCommandAsync(
@@ -61,10 +63,10 @@ public class InMemorySekibanExecutor(
                     lastEvent?.PartitionKeys.RootPartitionKey ?? "default");
                 var typedMultiProjectionState
                     = sekibanDomainTypes.MultiProjectorsType.ToTypedState(multiProjectionState);
-                var queryExecutor = new QueryExecutor();
                 var queryResult = await sekibanDomainTypes.QueryTypes.ExecuteAsQueryResult(
                     queryCommon,
-                    selector => typedMultiProjectionState.ToResultBox().ConveyorWrapTry(state => state).ToTask());
+                    selector => typedMultiProjectionState.ToResultBox().ConveyorWrapTry(state => state).ToTask(),
+                    serviceProvider);
                 return queryResult.ConveyorWrapTry(val => (TResult)val.GetValue());
             }
             return ResultBox<TResult>.Error(new ApplicationException("Projection failed"));
@@ -95,10 +97,10 @@ public class InMemorySekibanExecutor(
                     lastEvent?.PartitionKeys.RootPartitionKey ?? "default");
                 var typedMultiProjectionState
                     = sekibanDomainTypes.MultiProjectorsType.ToTypedState(multiProjectionState);
-                var queryExecutor = new QueryExecutor();
                 var queryResult = await sekibanDomainTypes.QueryTypes.ExecuteAsQueryResult(
                     queryCommon,
-                    selector => typedMultiProjectionState.ToResultBox().ConveyorWrapTry(state => state).ToTask());
+                    selector => typedMultiProjectionState.ToResultBox().ConveyorWrapTry(state => state).ToTask(),
+                    serviceProvider);
                 return queryResult.ConveyorWrapTry(val => (ListQueryResult<TResult>)val);
             }
             return ResultBox<ListQueryResult<TResult>>.Error(new ApplicationException("Projection failed"));

--- a/samples/AspireEventSample/Sekiban.Pure/Executors/InMemorySekibanExecutor.cs
+++ b/samples/AspireEventSample/Sekiban.Pure/Executors/InMemorySekibanExecutor.cs
@@ -12,10 +12,10 @@ namespace Sekiban.Pure.Executors;
 public class InMemorySekibanExecutor(
     SekibanDomainTypes sekibanDomainTypes,
     ICommandMetadataProvider metadataProvider,
-    Repository repository) : ISekibanExecutor
+    Repository repository, IServiceProvider serviceProvider) : ISekibanExecutor
 {
     public Repository Repository { get; set; } = repository;
-    private readonly CommandExecutor _commandExecutor = new() { EventTypes = sekibanDomainTypes.EventTypes };
+    private readonly CommandExecutor _commandExecutor = new(serviceProvider) { EventTypes = sekibanDomainTypes.EventTypes };
 
     public SekibanDomainTypes GetDomainTypes() => sekibanDomainTypes;
     public async Task<ResultBox<CommandResponse>> ExecuteCommandAsync(

--- a/samples/AspireEventSample/Sekiban.Pure/Query/IQueryContext.cs
+++ b/samples/AspireEventSample/Sekiban.Pure/Query/IQueryContext.cs
@@ -1,3 +1,7 @@
+using ResultBoxes;
 namespace Sekiban.Pure.Query;
 
-public interface IQueryContext;
+public interface IQueryContext
+{
+    ResultBox<T> GetService<T>() where T : notnull;
+}

--- a/samples/AspireEventSample/Sekiban.Pure/Query/IQueryTypes.cs
+++ b/samples/AspireEventSample/Sekiban.Pure/Query/IQueryTypes.cs
@@ -7,12 +7,14 @@ public interface IQueryTypes
     public Task<ResultBox<IQueryResult>> ExecuteAsQueryResult(
         IQueryCommon query,
         Func<IMultiProjectionEventSelector,
-            Task<ResultBox<IMultiProjectorStateCommon>>> repositoryLoader);
+            Task<ResultBox<IMultiProjectorStateCommon>>> repositoryLoader,
+        IServiceProvider serviceProvider);
 
     public Task<ResultBox<IListQueryResult>> ExecuteAsQueryResult(
         IListQueryCommon query,
         Func<IMultiProjectionEventSelector,
-            Task<ResultBox<IMultiProjectorStateCommon>>> repositoryLoader);
+            Task<ResultBox<IMultiProjectorStateCommon>>> repositoryLoader,
+        IServiceProvider serviceProvider);
 
     public ResultBox<IQueryResult> ToTypedQueryResult(QueryResultGeneral general);
     public ResultBox<IListQueryResult> ToTypedListQueryResult(ListQueryResultGeneral general);

--- a/samples/AspireEventSample/Sekiban.Pure/Query/QueryContext.cs
+++ b/samples/AspireEventSample/Sekiban.Pure/Query/QueryContext.cs
@@ -1,3 +1,8 @@
+using Microsoft.Extensions.DependencyInjection;
+using ResultBoxes;
 namespace Sekiban.Pure.Query;
 
-public record QueryContext : IQueryContext;
+public class QueryContext(IServiceProvider serviceProvider) : IQueryContext
+{
+    public ResultBox<T> GetService<T>() where T : notnull => ResultBox.CheckNull(serviceProvider.GetService<T>());
+}


### PR DESCRIPTION
This pull request introduces the use of `IServiceProvider` to various components in the `AspireEventSample` project to enable dependency injection. This change affects multiple files and methods, ensuring that the service provider is passed and utilized where necessary.

### Dependency Injection Integration:

* [`samples/AspireEventSample/AspireEventSample.UnitTest/AspireEventSampleUnitTest.cs`](diffhunk://#diff-28577f3bf9cbf115c36fb2b0d22bb69d767eabaa25c5a14b3b3d49f894565fcbL30-R31): Updated unit tests to include `IServiceProvider` in the `InMemorySekibanExecutor` instantiation. [[1]](diffhunk://#diff-28577f3bf9cbf115c36fb2b0d22bb69d767eabaa25c5a14b3b3d49f894565fcbL30-R31) [[2]](diffhunk://#diff-28577f3bf9cbf115c36fb2b0d22bb69d767eabaa25c5a14b3b3d49f894565fcbL44-R45) [[3]](diffhunk://#diff-28577f3bf9cbf115c36fb2b0d22bb69d767eabaa25c5a14b3b3d49f894565fcbL58-R59)

* [`samples/AspireEventSample/Sekiban.Pure.OrleansEventSourcing/AggregateProjectorGrain.cs`](diffhunk://#diff-df78b7f78058f8d5ae339b75ab7a867713e351d520ef4ad4d110e1bcc5ac6a73L10-R10): Added `IServiceProvider` parameter to the constructor and updated `CommandExecutor` instantiation. [[1]](diffhunk://#diff-df78b7f78058f8d5ae339b75ab7a867713e351d520ef4ad4d110e1bcc5ac6a73L10-R10) [[2]](diffhunk://#diff-df78b7f78058f8d5ae339b75ab7a867713e351d520ef4ad4d110e1bcc5ac6a73L105-R105)

* [`samples/AspireEventSample/Sekiban.Pure.OrleansEventSourcing/MultiProjectorGrain.cs`](diffhunk://#diff-a22d79940d9ceb214688c15fe82e4345b4deab77fbb58e9e9e4ef187a2589931L167-R171): Included `IServiceProvider` in `ExecuteAsQueryResult` method calls. [[1]](diffhunk://#diff-a22d79940d9ceb214688c15fe82e4345b4deab77fbb58e9e9e4ef187a2589931L167-R171) [[2]](diffhunk://#diff-a22d79940d9ceb214688c15fe82e4345b4deab77fbb58e9e9e4ef187a2589931L177-R182)

* [`samples/AspireEventSample/Sekiban.Pure/Command/Executor/CommandContext.cs`](diffhunk://#diff-0658f4cacf612f40f8cb8ee8ed55455c2a4b8577515798b7911369371e237b75L13-R22): Added `IServiceProvider` to the constructor and provided a method to retrieve services. [[1]](diffhunk://#diff-0658f4cacf612f40f8cb8ee8ed55455c2a4b8577515798b7911369371e237b75L13-R22) [[2]](diffhunk://#diff-0658f4cacf612f40f8cb8ee8ed55455c2a4b8577515798b7911369371e237b75L32-R37)

* [`samples/AspireEventSample/Sekiban.Pure/Executors/InMemorySekibanExecutor.cs`](diffhunk://#diff-61cfe92a2fa23cdd60e7f89dfd881f656b2e8b6f2230724314aa8076501423d4L15-R20): Modified the constructor to accept `IServiceProvider` and updated query execution methods to use it. [[1]](diffhunk://#diff-61cfe92a2fa23cdd60e7f89dfd881f656b2e8b6f2230724314aa8076501423d4L15-R20) [[2]](diffhunk://#diff-61cfe92a2fa23cdd60e7f89dfd881f656b2e8b6f2230724314aa8076501423d4L64-R69) [[3]](diffhunk://#diff-61cfe92a2fa23cdd60e7f89dfd881f656b2e8b6f2230724314aa8076501423d4L98-R103)