### PR TITLE
Add NUnit test project and update executor method names for consistency

### DIFF
--- a/samples/AspireEventSample/AspireEventSample.ApiService/Program.cs
+++ b/samples/AspireEventSample/AspireEventSample.ApiService/Program.cs
@@ -130,7 +130,7 @@ apiRoute
         "/registerbranch",
         async (
             [FromBody] RegisterBranch command,
-            [FromServices] SekibanOrleansExecutor executor) => await executor.ExecuteCommandAsync(command).UnwrapBox())
+            [FromServices] SekibanOrleansExecutor executor) => await executor.CommandAsync(command).UnwrapBox())
     .WithName("RegisterBranch")
     .WithOpenApi();
 apiRoute
@@ -138,7 +138,7 @@ apiRoute
         "/changebranchname",
         async (
             [FromBody] ChangeBranchName command,
-            [FromServices] SekibanOrleansExecutor executor) => await executor.ExecuteCommandAsync(command).UnwrapBox())
+            [FromServices] SekibanOrleansExecutor executor) => await executor.CommandAsync(command).UnwrapBox())
     .WithName("ChangeBranchName")
     .WithOpenApi();
 
@@ -180,7 +180,7 @@ apiRoute
         (
                 [FromRoute] string nameContains,
                 [FromServices] SekibanOrleansExecutor executor) =>
-            executor.ExecuteQueryAsync(new BranchExistsQuery(nameContains)).UnwrapBox())
+            executor.QueryAsync(new BranchExistsQuery(nameContains)).UnwrapBox())
     .WithName("BranchExists")
     .WithOpenApi();
 
@@ -190,7 +190,7 @@ apiRoute
         (
                 [FromQuery] string nameContains,
                 [FromServices] SekibanOrleansExecutor executor) =>
-            executor.ExecuteQueryAsync(new SimpleBranchListQuery(nameContains)).UnwrapBox())
+            executor.QueryAsync(new SimpleBranchListQuery(nameContains)).UnwrapBox())
     .WithName("SearchBranches")
     .WithOpenApi();
 apiRoute
@@ -199,7 +199,7 @@ apiRoute
         (
                 [FromQuery] string nameContains,
                 [FromServices] SekibanOrleansExecutor executor) =>
-            executor.ExecuteQueryAsync(new BranchQueryFromAggregateList(nameContains)).UnwrapBox())
+            executor.QueryAsync(new BranchQueryFromAggregateList(nameContains)).UnwrapBox())
     .WithName("SearchBranches2")
     .WithOpenApi();
 

--- a/samples/AspireEventSample/AspireEventSample.NUnitTest/AspireEventSample.NUnitTest.csproj
+++ b/samples/AspireEventSample/AspireEventSample.NUnitTest/AspireEventSample.NUnitTest.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
@@ -10,17 +11,18 @@
     <ItemGroup>
         <PackageReference Include="coverlet.collector" Version="6.0.2"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1"/>
-        <PackageReference Include="xunit" Version="2.9.2"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2"/>
+        <PackageReference Include="NUnit" Version="4.3.2"/>
+        <PackageReference Include="NUnit.Analyzers" Version="4.3.0"/>
+        <PackageReference Include="NUnit3TestAdapter" Version="4.6.0"/>
     </ItemGroup>
 
     <ItemGroup>
-        <Using Include="Xunit"/>
+        <Using Include="NUnit.Framework"/>
     </ItemGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\AspireEventSample.ApiService\AspireEventSample.ApiService.csproj"/>
-        <ProjectReference Include="..\Sekiban.Pure.xUnit\Sekiban.Pure.xUnit.csproj"/>
+        <ProjectReference Include="..\Sekiban.Pure.NUnit\Sekiban.Pure.NUnit.csproj"/>
     </ItemGroup>
 
 </Project>

--- a/samples/AspireEventSample/AspireEventSample.NUnitTest/AspireEventSampleUnitTest2.cs
+++ b/samples/AspireEventSample/AspireEventSample.NUnitTest/AspireEventSampleUnitTest2.cs
@@ -1,0 +1,57 @@
+using AspireEventSample.ApiService.Aggregates.Branches;
+using AspireEventSample.ApiService.Generated;
+using AspireEventSample.ApiService.Projections;
+using ResultBoxes;
+using Sekiban.Pure;
+using Sekiban.Pure.NUnit;
+namespace AspireEventSample.NUnitTest;
+
+public class AspireEventSampleUnitTest2 : SekibanInMemoryTestBase
+{
+    protected override SekibanDomainTypes GetDomainTypes() => AspireEventSampleApiServiceDomainTypes.Generate(
+        AspireEventSampleApiServiceEventsJsonContext.Default.Options);
+
+    [Test]
+    public Task RegisterBranchTest()
+        => GivenCommand(new RegisterBranch("DDD"))
+            .Do(response => Assert.That(response.Version, Is.EqualTo(1)))
+            .Conveyor(response => WhenCommand(new ChangeBranchName(response.PartitionKeys.AggregateId, "ES")))
+            .Do(response => Assert.That(response.Version, Is.EqualTo(2)))
+            .Conveyor(response => ThenGetAggregate<BranchProjector>(response.PartitionKeys))
+            .Conveyor(aggregate => aggregate.Payload.ToResultBox().Cast<Branch>())
+            .Do(payload => Assert.That(payload.Name, Is.EqualTo("ES")))
+            .UnwrapBox();
+
+    [Test]
+    public Task RegisterBranchAndQueryTest()
+        => GivenCommand(new RegisterBranch("DDD"))
+            .Conveyor(response => GivenCommand(new ChangeBranchName(response.PartitionKeys.AggregateId, "ES")))
+            .Conveyor(_ => ThenQuery(new BranchExistsQuery("DDD")))
+            .Do(queryResult => Assert.That(queryResult, Is.False))
+            .Conveyor(_ => ThenQuery(new BranchExistsQuery("ES")))
+            .Do(queryResult => Assert.That(queryResult, Is.True))
+            .UnwrapBox();
+    [Test]
+    public Task RegisterBranchAndListQueryTest()
+        => GivenCommand(new RegisterBranch("DDD"))
+            .Conveyor(response => GivenCommand(new ChangeBranchName(response.PartitionKeys.AggregateId, "ES")))
+            .Conveyor(_ => ThenQuery(new SimpleBranchListQuery("DDD")))
+            .Do(queryResult => Assert.That(queryResult.Items.Count(), Is.EqualTo(0)))
+            .Conveyor(_ => ThenQuery(new SimpleBranchListQuery("ES")))
+            .Do(queryResult => Assert.That(queryResult.Items.Count(), Is.EqualTo(1)))
+            .UnwrapBox();
+
+    [Test]
+    public Task RegisterTwoBranchTest()
+        => GivenCommand(new RegisterBranch("DDD"))
+            .Do(_ => Assert.That(Repository.Events, Has.Count.EqualTo(1)))
+            .Conveyor(_ => GivenCommand(new RegisterBranch("DDD2")))
+            .Do(_ => Assert.That(Repository.Events, Has.Count.EqualTo(2)))
+            .Do(response => Assert.That(response.Version, Is.EqualTo(1)))
+            .Conveyor(response => WhenCommand(new ChangeBranchName(response.PartitionKeys.AggregateId, "ES")))
+            .Do(response => Assert.That(response.Version, Is.EqualTo(2)))
+            .Conveyor(response => ThenGetAggregate<BranchProjector>(response.PartitionKeys))
+            .Conveyor(aggregate => aggregate.Payload.ToResultBox().Cast<Branch>())
+            .Do(payload => Assert.That(payload.Name, Is.EqualTo("ES")))
+            .UnwrapBox();
+}

--- a/samples/AspireEventSample/AspireEventSample.NUnitTest/UnitTest1.cs
+++ b/samples/AspireEventSample/AspireEventSample.NUnitTest/UnitTest1.cs
@@ -1,0 +1,15 @@
+﻿namespace AspireEventSample.NUnitTest;
+
+public class Tests
+{
+    [SetUp]
+    public void Setup()
+    {
+    }
+
+    [Test]
+    public void Test1()
+    {
+        Assert.Pass();
+    }
+}

--- a/samples/AspireEventSample/AspireEventSample.UnitTest/AspireEventSampleUnitTest.cs
+++ b/samples/AspireEventSample/AspireEventSample.UnitTest/AspireEventSampleUnitTest.cs
@@ -28,9 +28,13 @@ public class AspireEventSampleUnitTest
     [Fact]
     public async Task RegisterBranchTest()
     {
-        var executor = new InMemorySekibanExecutor(SekibanDomainTypes, CommandMetadataProvider, new Repository(), new ServiceCollection().BuildServiceProvider());
+        var executor = new InMemorySekibanExecutor(
+            SekibanDomainTypes,
+            CommandMetadataProvider,
+            new Repository(),
+            new ServiceCollection().BuildServiceProvider());
 
-        var result1 = await executor.ExecuteCommandAsync(new RegisterBranch("DDD"));
+        var result1 = await executor.CommandAsync(new RegisterBranch("DDD"));
         Assert.True(result1.IsSuccess);
         var value = result1.GetValue();
         Assert.NotNull(value);
@@ -42,24 +46,32 @@ public class AspireEventSampleUnitTest
     [Fact]
     public async Task SimpleBranchListQueryTest()
     {
-        var executor = new InMemorySekibanExecutor(SekibanDomainTypes, CommandMetadataProvider, new Repository(), new ServiceCollection().BuildServiceProvider());
+        var executor = new InMemorySekibanExecutor(
+            SekibanDomainTypes,
+            CommandMetadataProvider,
+            new Repository(),
+            new ServiceCollection().BuildServiceProvider());
 
         // Register a branch to generate events
-        var commandResult = await executor.ExecuteCommandAsync(new RegisterBranch("TestList"));
+        var commandResult = await executor.CommandAsync(new RegisterBranch("TestList"));
         Assert.True(commandResult.IsSuccess, "RegisterBranch command should succeed");
 
         var listQuery = new SimpleBranchListQuery("TestList");
-        var queryResult = await executor.ExecuteQueryAsync(listQuery);
+        var queryResult = await executor.QueryAsync(listQuery);
         Assert.True(queryResult.IsSuccess, "List query execution should be successful");
     }
 
     [Fact]
     public async Task LoadAggregateTest()
     {
-        var executor = new InMemorySekibanExecutor(SekibanDomainTypes, CommandMetadataProvider, new Repository(), new ServiceCollection().BuildServiceProvider());
+        var executor = new InMemorySekibanExecutor(
+            SekibanDomainTypes,
+            CommandMetadataProvider,
+            new Repository(),
+            new ServiceCollection().BuildServiceProvider());
 
         // Register a branch to generate events
-        var commandResult = await executor.ExecuteCommandAsync(new RegisterBranch("TestLoad"));
+        var commandResult = await executor.CommandAsync(new RegisterBranch("TestLoad"));
         Assert.True(commandResult.IsSuccess, "RegisterBranch command should succeed");
 
         var aggregateId = commandResult.GetValue().PartitionKeys.AggregateId;

--- a/samples/AspireEventSample/AspireEventSample.UnitTest/AspireEventSampleUnitTest2.cs
+++ b/samples/AspireEventSample/AspireEventSample.UnitTest/AspireEventSampleUnitTest2.cs
@@ -1,0 +1,58 @@
+using AspireEventSample.ApiService.Aggregates.Branches;
+using AspireEventSample.ApiService.Generated;
+using AspireEventSample.ApiService.Projections;
+using ResultBoxes;
+using Sekiban.Pure;
+using Sekiban.Pure.xUnit;
+namespace AspireEventSample.UnitTest;
+
+public class AspireEventSampleUnitTest2 : SekibanInMemoryTestBase
+{
+    protected override SekibanDomainTypes GetDomainTypes() => AspireEventSampleApiServiceDomainTypes.Generate(
+        AspireEventSampleApiServiceEventsJsonContext.Default.Options);
+
+    [Fact]
+    public Task RegisterBranchTest()
+        => GivenCommand(new RegisterBranch("DDD"))
+            .Do(response => Assert.Equal(1, response.Version))
+            .Conveyor(response => WhenCommand(new ChangeBranchName(response.PartitionKeys.AggregateId, "ES")))
+            .Do(response => Assert.Equal(2, response.Version))
+            .Conveyor(response => ThenGetAggregate<BranchProjector>(response.PartitionKeys))
+            .Conveyor(aggregate => aggregate.Payload.ToResultBox().Cast<Branch>())
+            .Do(payload => Assert.Equal("ES", payload.Name))
+            .UnwrapBox();
+
+    [Fact]
+    public Task RegisterTwoBranchTest()
+        => GivenCommand(new RegisterBranch("DDD"))
+            .Do(_ => Assert.Single(Repository.Events))
+            .Conveyor(_ => GivenCommand(new RegisterBranch("DDD2")))
+            .Do(_ => Assert.Equal(2, Repository.Events.Count))
+            .Do(response => Assert.Equal(1, response.Version))
+            .Conveyor(response => WhenCommand(new ChangeBranchName(response.PartitionKeys.AggregateId, "ES")))
+            .Do(response => Assert.Equal(2, response.Version))
+            .Conveyor(response => ThenGetAggregate<BranchProjector>(response.PartitionKeys))
+            .Conveyor(aggregate => aggregate.Payload.ToResultBox().Cast<Branch>())
+            .Do(payload => Assert.Equal("ES", payload.Name))
+            .UnwrapBox();
+
+    [Fact]
+    public Task RegisterBranchAndQueryTest()
+        => GivenCommand(new RegisterBranch("DDD"))
+            .Conveyor(response => GivenCommand(new ChangeBranchName(response.PartitionKeys.AggregateId, "ES")))
+            .Conveyor(_ => ThenQuery(new BranchExistsQuery("DDD")))
+            .Do(Assert.False)
+            .Conveyor(_ => ThenQuery(new BranchExistsQuery("ES")))
+            .Do(Assert.True)
+            .UnwrapBox();
+
+    [Fact]
+    public Task RegisterBranchAndListQueryTest()
+        => GivenCommand(new RegisterBranch("DDD"))
+            .Conveyor(response => GivenCommand(new ChangeBranchName(response.PartitionKeys.AggregateId, "ES")))
+            .Conveyor(_ => ThenQuery(new SimpleBranchListQuery("DDD")))
+            .Do(queryResult => Assert.Empty(queryResult.Items))
+            .Conveyor(_ => ThenQuery(new SimpleBranchListQuery("ES")))
+            .Do(queryResult => Assert.Single(queryResult.Items))
+            .UnwrapBox();
+}

--- a/samples/AspireEventSample/AspireEventSample.sln
+++ b/samples/AspireEventSample/AspireEventSample.sln
@@ -26,6 +26,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sekiban.Pure.Postgres", "Se
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sekiban.Pure.AspNetCore", "Sekiban.Pure.AspNetCore\Sekiban.Pure.AspNetCore.csproj", "{FDD6FC95-6BDB-4D40-BFFD-8251B14FFB80}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sekiban.Pure.xUnit", "Sekiban.Pure.xUnit\Sekiban.Pure.xUnit.csproj", "{454BA9B1-557D-4FD1-80F5-035E976C4B3A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sekiban.Pure.NUnit", "Sekiban.Pure.NUnit\Sekiban.Pure.NUnit.csproj", "{C8F11FAA-FCAF-42F9-8EEF-5C8120097FC6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AspireEventSample.NUnitTest", "AspireEventSample.NUnitTest\AspireEventSample.NUnitTest.csproj", "{3B134D75-1000-4F0B-B293-5D06D2B32A73}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -80,6 +86,18 @@ Global
 		{FDD6FC95-6BDB-4D40-BFFD-8251B14FFB80}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FDD6FC95-6BDB-4D40-BFFD-8251B14FFB80}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FDD6FC95-6BDB-4D40-BFFD-8251B14FFB80}.Release|Any CPU.Build.0 = Release|Any CPU
+		{454BA9B1-557D-4FD1-80F5-035E976C4B3A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{454BA9B1-557D-4FD1-80F5-035E976C4B3A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{454BA9B1-557D-4FD1-80F5-035E976C4B3A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{454BA9B1-557D-4FD1-80F5-035E976C4B3A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C8F11FAA-FCAF-42F9-8EEF-5C8120097FC6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C8F11FAA-FCAF-42F9-8EEF-5C8120097FC6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C8F11FAA-FCAF-42F9-8EEF-5C8120097FC6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C8F11FAA-FCAF-42F9-8EEF-5C8120097FC6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3B134D75-1000-4F0B-B293-5D06D2B32A73}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3B134D75-1000-4F0B-B293-5D06D2B32A73}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3B134D75-1000-4F0B-B293-5D06D2B32A73}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3B134D75-1000-4F0B-B293-5D06D2B32A73}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/samples/AspireEventSample/Sekiban.Pure.NUnit/Sekiban.Pure.NUnit.csproj
+++ b/samples/AspireEventSample/Sekiban.Pure.NUnit/Sekiban.Pure.NUnit.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <LangVersion>preview</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Sekiban.Pure\Sekiban.Pure.csproj"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.2"/>
+        <PackageReference Include="NUnit" Version="4.3.2"/>
+    </ItemGroup>
+
+</Project>

--- a/samples/AspireEventSample/Sekiban.Pure.NUnit/SekibanInMemoryTestBase.cs
+++ b/samples/AspireEventSample/Sekiban.Pure.NUnit/SekibanInMemoryTestBase.cs
@@ -1,0 +1,74 @@
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using ResultBoxes;
+using Sekiban.Pure.Aggregates;
+using Sekiban.Pure.Command.Executor;
+using Sekiban.Pure.Command.Handlers;
+using Sekiban.Pure.Documents;
+using Sekiban.Pure.Events;
+using Sekiban.Pure.Executors;
+using Sekiban.Pure.Projectors;
+using Sekiban.Pure.Query;
+using Sekiban.Pure.Repositories;
+namespace Sekiban.Pure.NUnit;
+
+[TestFixture]
+public abstract class SekibanInMemoryTestBase
+{
+    /// <summary>
+    ///     Each test case implements domain types through this abstract property
+    /// </summary>
+    private SekibanDomainTypes DomainTypes => GetDomainTypes();
+    protected abstract SekibanDomainTypes GetDomainTypes();
+
+    private ICommandMetadataProvider _commandMetadataProvider;
+    private IServiceProvider _serviceProvider;
+    private ISekibanExecutor _executor;
+    protected Repository Repository
+    {
+        get;
+        private set;
+    }
+    [SetUp]
+    public virtual void SetUp()
+    {
+        _commandMetadataProvider = new FunctionCommandMetadataProvider(() => "test");
+        _serviceProvider = new ServiceCollection().BuildServiceProvider();
+        Repository = new Repository();
+        _executor = new InMemorySekibanExecutor(DomainTypes, _commandMetadataProvider, Repository, _serviceProvider);
+    }
+
+    /// <summary>
+    ///     Execute command in Given phase
+    /// </summary>
+    protected Task<ResultBox<CommandResponse>> GivenCommand(
+        ICommandWithHandlerSerializable command,
+        IEvent? relatedEvent = null) =>
+        _executor.CommandAsync(command, relatedEvent);
+
+    /// <summary>
+    ///     Execute command in When phase
+    /// </summary>
+    protected Task<ResultBox<CommandResponse>> WhenCommand(
+        ICommandWithHandlerSerializable command,
+        IEvent? relatedEvent = null) =>
+        _executor.CommandAsync(command, relatedEvent);
+
+    /// <summary>
+    ///     Get aggregate in Then phase
+    /// </summary>
+    protected Task<ResultBox<Aggregate>> ThenGetAggregate<TAggregateProjector>(PartitionKeys partitionKeys)
+        where TAggregateProjector : IAggregateProjector, new()
+        => _executor.LoadAggregateAsync<TAggregateProjector>(partitionKeys);
+
+    protected Task<ResultBox<TResult>> ThenQuery<TResult>(IQueryCommon<TResult> query) where TResult : notnull
+        => _executor.QueryAsync(query);
+
+    protected Task<ResultBox<ListQueryResult<TResult>>> ThenQuery<TResult>(IListQueryCommon<TResult> query)
+        where TResult : notnull
+        => _executor.QueryAsync(query);
+
+    protected Task<ResultBox<TMultiProjector>> ThenGetMultiProjector<TMultiProjector>()
+        where TMultiProjector : IMultiProjector<TMultiProjector>, new()
+        => Repository.LoadMultiProjection<TMultiProjector>(MultiProjectionEventSelector.All).Remap(x => x.Payload);
+}

--- a/samples/AspireEventSample/Sekiban.Pure.OrleansEventSourcing/SekibanOrleansExecutor.cs
+++ b/samples/AspireEventSample/Sekiban.Pure.OrleansEventSourcing/SekibanOrleansExecutor.cs
@@ -16,7 +16,7 @@ public class SekibanOrleansExecutor(
 {
 
     public SekibanDomainTypes GetDomainTypes() => sekibanDomainTypes;
-    public async Task<ResultBox<CommandResponse>> ExecuteCommandAsync(
+    public async Task<ResultBox<CommandResponse>> CommandAsync(
         ICommandWithHandlerSerializable command,
         IEvent? relatedEvent = null)
     {
@@ -33,7 +33,7 @@ public class SekibanOrleansExecutor(
             OrleansCommandMetadata.FromCommandMetadata(metadataProvider.GetMetadata()));
         return toReturn.ToCommandResponse(sekibanDomainTypes.EventTypes);
     }
-    public async Task<ResultBox<TResult>> ExecuteQueryAsync<TResult>(IQueryCommon<TResult> queryCommon)
+    public async Task<ResultBox<TResult>> QueryAsync<TResult>(IQueryCommon<TResult> queryCommon)
         where TResult : notnull
     {
         var projectorResult = sekibanDomainTypes.QueryTypes.GetMultiProjector(queryCommon);
@@ -52,7 +52,7 @@ public class SekibanOrleansExecutor(
             .ToTypedQueryResult(result.ToQueryResultGeneral())
             .Remap(r => (TResult)r.GetValue());
     }
-    public async Task<ResultBox<ListQueryResult<TResult>>> ExecuteQueryAsync<TResult>(
+    public async Task<ResultBox<ListQueryResult<TResult>>> QueryAsync<TResult>(
         IListQueryCommon<TResult> queryCommon)
     {
         var projectorResult = sekibanDomainTypes.QueryTypes.GetMultiProjector(queryCommon);

--- a/samples/AspireEventSample/Sekiban.Pure.xUnit/Sekiban.Pure.xUnit.csproj
+++ b/samples/AspireEventSample/Sekiban.Pure.xUnit/Sekiban.Pure.xUnit.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <LangVersion>preview</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Sekiban.Pure\Sekiban.Pure.csproj"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.2"/>
+    </ItemGroup>
+
+</Project>

--- a/samples/AspireEventSample/Sekiban.Pure.xUnit/SekibanInMemoryTestBase.cs
+++ b/samples/AspireEventSample/Sekiban.Pure.xUnit/SekibanInMemoryTestBase.cs
@@ -1,0 +1,67 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using ResultBoxes;
+using Sekiban.Pure.Aggregates;
+using Sekiban.Pure.Command.Executor;
+using Sekiban.Pure.Command.Handlers;
+using Sekiban.Pure.Documents;
+using Sekiban.Pure.Events;
+using Sekiban.Pure.Executors;
+using Sekiban.Pure.Projectors;
+using Sekiban.Pure.Query;
+using Sekiban.Pure.Repositories;
+namespace Sekiban.Pure.xUnit;
+
+public abstract class SekibanInMemoryTestBase
+{
+    /// <summary>
+    ///     各テストケースごとにドメインタイプを実装するための抽象プロパティ
+    /// </summary>
+    private SekibanDomainTypes DomainTypes => GetDomainTypes();
+    protected abstract SekibanDomainTypes GetDomainTypes();
+
+    protected ICommandMetadataProvider CommandMetadataProvider { get; }
+        = new FunctionCommandMetadataProvider(() => "test");
+
+    protected IServiceProvider ServiceProvider { get; }
+        = new ServiceCollection().BuildServiceProvider();
+
+    protected Repository Repository { get; } = new();
+
+    protected ISekibanExecutor Executor { get; }
+
+    public SekibanInMemoryTestBase() =>
+        Executor = new InMemorySekibanExecutor(DomainTypes, CommandMetadataProvider, Repository, ServiceProvider);
+
+    /// <summary>
+    ///     Givenフェーズのコマンド実行
+    /// </summary>
+    protected Task<ResultBox<CommandResponse>> GivenCommand(
+        ICommandWithHandlerSerializable command,
+        IEvent? relatedEvent = null) =>
+        Executor.CommandAsync(command, relatedEvent);
+
+    /// <summary>
+    ///     Whenフェーズのコマンド実行
+    /// </summary>
+    protected Task<ResultBox<CommandResponse>> WhenCommand(
+        ICommandWithHandlerSerializable command,
+        IEvent? relatedEvent = null) =>
+        Executor.CommandAsync(command, relatedEvent);
+
+    /// <summary>
+    ///     Thenフェーズの集約取得
+    /// </summary>
+    protected Task<ResultBox<Aggregate>> ThenGetAggregate<TAggregateProjector>(PartitionKeys partitionKeys)
+        where TAggregateProjector : IAggregateProjector, new()
+        => Executor.LoadAggregateAsync<TAggregateProjector>(partitionKeys);
+
+    protected Task<ResultBox<TResult>> ThenQuery<TResult>(IQueryCommon<TResult> query) where TResult : notnull
+        => Executor.QueryAsync(query);
+    protected Task<ResultBox<ListQueryResult<TResult>>> ThenQuery<TResult>(IListQueryCommon<TResult> query)
+        where TResult : notnull
+        => Executor.QueryAsync(query);
+
+    protected Task<ResultBox<TMultiProjector>> ThenGetMultiProjector<TMultiProjector>()
+        where TMultiProjector : IMultiProjector<TMultiProjector>, new()
+        => Repository.LoadMultiProjection<TMultiProjector>(MultiProjectionEventSelector.All).Remap(x => x.Payload);
+}

--- a/samples/AspireEventSample/Sekiban.Pure/Executors/ISekibanExecutor.cs
+++ b/samples/AspireEventSample/Sekiban.Pure/Executors/ISekibanExecutor.cs
@@ -11,12 +11,12 @@ namespace Sekiban.Pure.Executors;
 public interface ISekibanExecutor
 {
     public SekibanDomainTypes GetDomainTypes();
-    public Task<ResultBox<CommandResponse>> ExecuteCommandAsync(
+    public Task<ResultBox<CommandResponse>> CommandAsync(
         ICommandWithHandlerSerializable command,
         IEvent? relatedEvent = null);
-    public Task<ResultBox<TResult>> ExecuteQueryAsync<TResult>(IQueryCommon<TResult> queryCommon)
+    public Task<ResultBox<TResult>> QueryAsync<TResult>(IQueryCommon<TResult> queryCommon)
         where TResult : notnull;
-    public Task<ResultBox<ListQueryResult<TResult>>> ExecuteQueryAsync<TResult>(IListQueryCommon<TResult> queryCommon)
+    public Task<ResultBox<ListQueryResult<TResult>>> QueryAsync<TResult>(IListQueryCommon<TResult> queryCommon)
         where TResult : notnull;
     public Task<ResultBox<Aggregate>> LoadAggregateAsync<TAggregateProjector>(PartitionKeys partitionKeys)
         where TAggregateProjector : IAggregateProjector, new();

--- a/samples/AspireEventSample/Sekiban.Pure/Executors/InMemorySekibanExecutor.cs
+++ b/samples/AspireEventSample/Sekiban.Pure/Executors/InMemorySekibanExecutor.cs
@@ -20,7 +20,7 @@ public class InMemorySekibanExecutor(
         { EventTypes = sekibanDomainTypes.EventTypes };
 
     public SekibanDomainTypes GetDomainTypes() => sekibanDomainTypes;
-    public async Task<ResultBox<CommandResponse>> ExecuteCommandAsync(
+    public async Task<ResultBox<CommandResponse>> CommandAsync(
         ICommandWithHandlerSerializable command,
         IEvent? relatedEvent = null)
     {
@@ -39,7 +39,7 @@ public class InMemorySekibanExecutor(
             (pk, pj) => Repository.Load(pk, pj).ToTask(),
             (_, events) => Repository.Save(events).ToTask());
     }
-    public async Task<ResultBox<TResult>> ExecuteQueryAsync<TResult>(IQueryCommon<TResult> queryCommon)
+    public async Task<ResultBox<TResult>> QueryAsync<TResult>(IQueryCommon<TResult> queryCommon)
         where TResult : notnull
     {
         var projectorResult = sekibanDomainTypes.QueryTypes.GetMultiProjector(queryCommon);
@@ -73,7 +73,7 @@ public class InMemorySekibanExecutor(
         }
         return ResultBox<TResult>.Error(new ApplicationException("Projector not found"));
     }
-    public async Task<ResultBox<ListQueryResult<TResult>>> ExecuteQueryAsync<TResult>(
+    public async Task<ResultBox<ListQueryResult<TResult>>> QueryAsync<TResult>(
         IListQueryCommon<TResult> queryCommon) where TResult : notnull
     {
         var projectorResult = sekibanDomainTypes.QueryTypes.GetMultiProjector(queryCommon);

--- a/samples/AspireEventSample/Sekiban.Pure/Sekiban.Pure.csproj
+++ b/samples/AspireEventSample/Sekiban.Pure/Sekiban.Pure.csproj
@@ -9,12 +9,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Serialization.Abstractions" Version="9.0.1" />
-        <PackageReference Include="ResultBoxes" Version="0.3.29"/>
+        <PackageReference Include="Microsoft.Orleans.Serialization.Abstractions" Version="9.0.1"/>
+        <PackageReference Include="ResultBoxes" Version="0.3.30"/>
     </ItemGroup>
 
     <ItemGroup>
-      <Folder Include="Cache\" />
+        <Folder Include="Cache\"/>
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This pull request includes several changes to the `AspireEventSample` project, focusing on refactoring method names for consistency, adding new unit tests, and updating project files. The most important changes include renaming methods in the `SekibanOrleansExecutor` class, adding new NUnit and xUnit test projects, and updating solution and project files to include these new test projects.

Method Refactoring:
* [`samples/AspireEventSample/Sekiban.Pure.OrleansEventSourcing/SekibanOrleansExecutor.cs`](diffhunk://#diff-a8e25f418d2a3ef59ee46fda160e6508cd04ce33f5c46f62b396266a836d1810L19-R19): Renamed `ExecuteCommandAsync` to `CommandAsync` and `ExecuteQueryAsync` to `QueryAsync` for better consistency and readability. [[1]](diffhunk://#diff-a8e25f418d2a3ef59ee46fda160e6508cd04ce33f5c46f62b396266a836d1810L19-R19) [[2]](diffhunk://#diff-a8e25f418d2a3ef59ee46fda160e6508cd04ce33f5c46f62b396266a836d1810L36-R36) [[3]](diffhunk://#diff-a8e25f418d2a3ef59ee46fda160e6508cd04ce33f5c46f62b396266a836d1810L55-R55)
* [`samples/AspireEventSample/AspireEventSample.ApiService/Program.cs`](diffhunk://#diff-cf5d5423f99488fa5b480ed2e7c540ff2b19c0f7cdb4df2c879bb95d1aac1517L133-R141): Updated method calls to reflect the renaming of `ExecuteCommandAsync` to `CommandAsync` and `ExecuteQueryAsync` to `QueryAsync`. [[1]](diffhunk://#diff-cf5d5423f99488fa5b480ed2e7c540ff2b19c0f7cdb4df2c879bb95d1aac1517L133-R141) [[2]](diffhunk://#diff-cf5d5423f99488fa5b480ed2e7c540ff2b19c0f7cdb4df2c879bb95d1aac1517L183-R183) [[3]](diffhunk://#diff-cf5d5423f99488fa5b480ed2e7c540ff2b19c0f7cdb4df2c879bb95d1aac1517L193-R193) [[4]](diffhunk://#diff-cf5d5423f99488fa5b480ed2e7c540ff2b19c0f7cdb4df2c879bb95d1aac1517L202-R202)
* [`samples/AspireEventSample/AspireEventSample.UnitTest/AspireEventSampleUnitTest.cs`](diffhunk://#diff-28577f3bf9cbf115c36fb2b0d22bb69d767eabaa25c5a14b3b3d49f894565fcbL31-R37): Updated method calls to reflect the renaming of `ExecuteCommandAsync` to `CommandAsync` and `ExecuteQueryAsync` to `QueryAsync`. [[1]](diffhunk://#diff-28577f3bf9cbf115c36fb2b0d22bb69d767eabaa25c5a14b3b3d49f894565fcbL31-R37) [[2]](diffhunk://#diff-28577f3bf9cbf115c36fb2b0d22bb69d767eabaa25c5a14b3b3d49f894565fcbL45-R74)

New Unit Test Projects:
* [`samples/AspireEventSample/AspireEventSample.NUnitTest/AspireEventSample.NUnitTest.csproj`](diffhunk://#diff-a50623f9723b329ba5e0422558b29c86b299c361f6b66ee20f4dc47b2553b832R1-R28): Added a new NUnit test project with references to necessary packages and project dependencies.
* [`samples/AspireEventSample/AspireEventSample.NUnitTest/AspireEventSampleUnitTest2.cs`](diffhunk://#diff-69308fde01240e58b364ace447fb090925d9c2586f90e2a2d5c2f424121dc47aR1-R57): Added new NUnit tests for `RegisterBranchTest`, `RegisterBranchAndQueryTest`, `RegisterBranchAndListQueryTest`, and `RegisterTwoBranchTest`.
* [`samples/AspireEventSample/AspireEventSample.NUnitTest/UnitTest1.cs`](diffhunk://#diff-2c9041e32419ffbfb3ebe9c6c5bc5109a9d4bbd76b54c01a25c8c241e21fd4e9R1-R15): Added a basic NUnit test class with a setup method and a simple test.
* [`samples/AspireEventSample/Sekiban.Pure.NUnit/Sekiban.Pure.NUnit.csproj`](diffhunk://#diff-1819f12b381a7c2c124cdc108db90c1820f95268a5418ee524e57cd936b299c3R1-R19): Added a new project for NUnit-specific base test classes.
* [`samples/AspireEventSample/Sekiban.Pure.NUnit/SekibanInMemoryTestBase.cs`](diffhunk://#diff-ffab9f52d9ce0e047a356ec14fcf0cb0b0ae8a37317a8d72086e2d7679d59374R1-R74): Added a new base class for NUnit tests, providing common setup and utility methods for in-memory testing.

Solution and Project File Updates:
* [`samples/AspireEventSample/AspireEventSample.sln`](diffhunk://#diff-1a31790530ba77ac7b2afd3a823fe043b8bd3e2825c9e47d91a91a1031abfaffR29-R34): Updated the solution file to include the new NUnit and xUnit test projects. [[1]](diffhunk://#diff-1a31790530ba77ac7b2afd3a823fe043b8bd3e2825c9e47d91a91a1031abfaffR29-R34) [[2]](diffhunk://#diff-1a31790530ba77ac7b2afd3a823fe043b8bd3e2825c9e47d91a91a1031abfaffR89-R100)
* [`samples/AspireEventSample/AspireEventSample.UnitTest/AspireEventSample.UnitTest.csproj`](diffhunk://#diff-42e9087df27d4872f1d5992e83778b4e875548c49a3b46273bc7d0fd2c5a8bfdR23): Added a reference to the `Sekiban.Pure.xUnit` project.